### PR TITLE
테스트 시 H2를 사용하도록 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.projectlombok:lombok:1.18.28'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2:2.2.220'
 }
 
 tasks.named('test') {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,9 @@
+spring:
+  profiles:
+    include: test
+  datasource:
+    driver-class-name: org.h2.Driver
+
+  mail:
+    username: test
+    password: 1234


### PR DESCRIPTION
### 목적
- 테스트 시 MariaDB 보다 가벼운 H2를 사용하도록 수정

### 개발 내용
- build.gradle 리팩토링
- 테스트 application.yaml 파일 생성