### PR TITLE
여행 수정 시 날짜 체크 수정

### DIFF
--- a/src/main/java/com/fc/toy_project2/domain/trip/service/TripService.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/service/TripService.java
@@ -108,8 +108,8 @@ public class TripService {
                     max = ((Accommodation) itinerary).getCheckIn().toLocalDate();
                 }
             } else {
-                if (((Visit) itinerary).getDepartureTime().toLocalDate().isBefore(max)) {
-                    max = ((Visit) itinerary).getDepartureTime().toLocalDate();
+                if (((Visit) itinerary).getArrivalTime().toLocalDate().isBefore(max)) {
+                    max = ((Visit) itinerary).getArrivalTime().toLocalDate();
                 }
             }
         }
@@ -134,8 +134,8 @@ public class TripService {
                     min = ((Accommodation) itinerary).getCheckOut().toLocalDate();
                 }
             } else {
-                if (((Visit) itinerary).getArrivalTime().toLocalDate().isAfter(min)) {
-                    min = ((Visit) itinerary).getArrivalTime().toLocalDate();
+                if (((Visit) itinerary).getDepartureTime().toLocalDate().isAfter(min)) {
+                    min = ((Visit) itinerary).getDepartureTime().toLocalDate();
                 }
             }
         }


### PR DESCRIPTION
### 문제 상황
- 여행 수정 시 최대 여행 시작일을 구할 때 출발일시를 체크하고, 최소 여행 종료일을 구할 때는 도착일시를 체크했습니다. 
- 하지만, Visit의 경우 도착일시부터 출발일시까지 체류하는 것을 의미하는 여정입니다. 따라서 최대 여행 시작일을 구할 때는 도착일시를 체크하고, 최소 여행 종료일을 구할 때는 출발일시를 체크해야 합니다. 

### 해결 방안(수정 내용)
- Visit의 경우 최대 여행 시작일을 구할 때는 도착일시를 체크하고, 최소 여행 종료일을 구할 때는 출발일시를 체크하도록 수정함.