### PR TITLE
REST Docs로 만들어진 html 복사 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,8 @@ out/
 ### VS Code ###
 .vscode/
 
+### Application.yaml ###
 **/*.yaml
+
+### REST Docs Html ###
+**.*.html

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 **/*.yaml
 
 ### REST Docs Html ###
-**.*.html
+**/*.html

--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,12 @@ asciidoctor {
     dependsOn test
 }
 
-bootJar {
+tasks.register('copyDocument', Copy) {
     dependsOn asciidoctor
-    from("${asciidoctor.outputDir}/html5") {
-        into 'static/docs'
-    }
+    from file("build/docs/asciidoc/")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }


### PR DESCRIPTION
### 문제 상황
- REST Docs 도입으로 만들어진 html 파일이 resource/static/ 폴더에 복사되지 않는 문제 발견

### 해결 방안 (개발 내용)
- html 복사 부분 수정
- html은 gitignore 처리