### PR TITLE
Trip API 요청 및 응답 DTO 변수명 및 URI 수정

### DIFF
--- a/src/main/java/com/fc/toy_project2/domain/trip/controller/TripRestController.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/controller/TripRestController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/trip")
+@RequestMapping("/api/trips")
 public class TripRestController {
 
     private final TripService tripService;

--- a/src/main/java/com/fc/toy_project2/domain/trip/dto/request/UpdateTripRequestDTO.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/dto/request/UpdateTripRequestDTO.java
@@ -17,9 +17,9 @@ import lombok.NoArgsConstructor;
 public class UpdateTripRequestDTO {
 
     @NotNull(message = "수정할 여행 정보 ID를 입력하세요.")
-    private Long id;
+    private Long tripId;
     @NotBlank(message = "여행 이름을 입력하세요.")
-    private String name;
+    private String tripName;
     @NotBlank(message = "여행 시작일을 입력하세요.(yyyy-MM-dd)")
     private String startDate;
     @NotBlank(message = "여행 종료일을 입력하세요.(yyyy-MM-dd)")

--- a/src/main/java/com/fc/toy_project2/domain/trip/dto/response/TripResponseDTO.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/dto/response/TripResponseDTO.java
@@ -10,8 +10,8 @@ import lombok.Getter;
 @Builder
 public class TripResponseDTO {
 
-    private Long id;
-    private String name;
+    private Long tripId;
+    private String tripName;
     private String startDate;
     private String endDate;
     private Boolean isDomestic;

--- a/src/main/java/com/fc/toy_project2/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/entity/Trip.java
@@ -70,7 +70,7 @@ public class Trip {
      * @return TripResponseDTO
      */
     public TripResponseDTO toTripResponseDTO() {
-        return TripResponseDTO.builder().id(this.id).name(this.name)
+        return TripResponseDTO.builder().tripId(this.id).tripName(this.name)
             .startDate(localDateToString(this.startDate)).endDate(localDateToString(this.endDate))
             .isDomestic(this.isDomestic).build();
     }
@@ -81,7 +81,7 @@ public class Trip {
      * @param updateTripRequestDTO 여행 정보 수정 요청 DTO
      */
     public void updateTrip(UpdateTripRequestDTO updateTripRequestDTO) {
-        this.name = updateTripRequestDTO.getName();
+        this.name = updateTripRequestDTO.getTripName();
         this.startDate = DateTypeFormatterUtil.dateFormatter(updateTripRequestDTO.getStartDate());
         this.endDate = DateTypeFormatterUtil.dateFormatter(updateTripRequestDTO.getEndDate());
         this.isDomestic = updateTripRequestDTO.getIsDomestic();

--- a/src/main/java/com/fc/toy_project2/domain/trip/service/TripService.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/service/TripService.java
@@ -80,7 +80,7 @@ public class TripService {
     }
 
     public TripResponseDTO updateTrip(UpdateTripRequestDTO updateTripRequestDTO) {
-        Trip trip = getTrip(updateTripRequestDTO.getId());
+        Trip trip = getTrip(updateTripRequestDTO.getTripId());
         checkTripDate(trip,
             DateTypeFormatterUtil.dateFormatter(updateTripRequestDTO.getStartDate()),
             DateTypeFormatterUtil.dateFormatter(updateTripRequestDTO.getEndDate()));

--- a/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
@@ -59,7 +59,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         given(tripService.postTrip(any(PostTripRequestDTO.class))).willReturn(trip);
 
         // when, then
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/trip")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/trips")
                 .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isCreated()).andDo(restDoc.document(
@@ -96,7 +96,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         given(tripService.getTrips()).willReturn(trips);
 
         // when, then
-        mockMvc.perform(get("/api/trip")).andExpect(status().isOk()).andDo(restDoc.document(
+        mockMvc.perform(get("/api/trips")).andExpect(status().isOk()).andDo(restDoc.document(
             responseFields(responseCommon()).and(
                 fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
                 fieldWithPath("data[].tripId").type(JsonFieldType.NUMBER).description("여행 식별자"),
@@ -116,7 +116,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
         // when, then
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/trip/{tripId}", 1L))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/trips/{tripId}", 1L))
             .andExpect(status().isOk()).andDo(
                 restDoc.document(pathParameters(parameterWithName("tripId").description("여행 식별자")),
                     responseFields(responseCommon()).and(
@@ -141,7 +141,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         given(tripService.updateTrip(any(UpdateTripRequestDTO.class))).willReturn(trip);
 
         // when, then
-        mockMvc.perform(patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+        mockMvc.perform(patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andDo(
             restDoc.document(requestFields(
                     fieldWithPath("tripId").type(JsonFieldType.NUMBER).description("여행 식별자").attributes(
@@ -178,7 +178,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
         //when, then
-        mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/trip/{tripId}", 1L))
+        mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/trips/{tripId}", 1L))
             .andExpect(status().isOk()).andDo(restDoc.document(
                 pathParameters(parameterWithName("tripId").description("여행 식별자")),
                 responseFields(responseCommon()).and(fieldWithPath("data").type(null).description("응답데이터 없음"))));

--- a/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
@@ -54,7 +54,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         // given
         PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
             .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
-        TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+        TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
             .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
         given(tripService.postTrip(any(PostTripRequestDTO.class))).willReturn(trip);
 
@@ -74,8 +74,8 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                         .attributes(key("constraints").value(postDescriptions.descriptionsForProperty("isDomestic")))),
                 responseFields(responseCommon()).and(
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
-                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("여행 식별자"),
-                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("여행 이름"),
+                    fieldWithPath("data.tripId").type(JsonFieldType.NUMBER).description("여행 식별자"),
+                    fieldWithPath("data.tripName").type(JsonFieldType.STRING).description("여행 이름"),
                     fieldWithPath("data.startDate").type(JsonFieldType.STRING).description("여행 시작일"),
                     fieldWithPath("data.endDate").type(JsonFieldType.STRING).description("여행 종료일"),
                     fieldWithPath("data.isDomestic").type(JsonFieldType.BOOLEAN).description("국내 여행 여부"))));
@@ -87,11 +87,11 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
     void getTrips() throws Exception {
         // given
         List<TripResponseDTO> trips = new ArrayList<>();
-        trips.add(TripResponseDTO.builder().id(1L).name("제주도 여행").startDate("2023-10-23")
+        trips.add(TripResponseDTO.builder().tripId(1L).tripName("제주도 여행").startDate("2023-10-23")
             .endDate("2023-10-27").isDomestic(true).build());
-        trips.add(TripResponseDTO.builder().id(2L).name("속초 겨울바다 여행").startDate("2023-11-27")
+        trips.add(TripResponseDTO.builder().tripId(2L).tripName("속초 겨울바다 여행").startDate("2023-11-27")
             .endDate("2023-11-29").isDomestic(true).build());
-        trips.add(TripResponseDTO.builder().id(3L).name("크리스마스 미국 여행").startDate("2023-12-24")
+        trips.add(TripResponseDTO.builder().tripId(3L).tripName("크리스마스 미국 여행").startDate("2023-12-24")
             .endDate("2023-12-26").isDomestic(false).build());
         given(tripService.getTrips()).willReturn(trips);
 
@@ -99,8 +99,8 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         mockMvc.perform(get("/api/trip")).andExpect(status().isOk()).andDo(restDoc.document(
             responseFields(responseCommon()).and(
                 fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
-                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("여행 식별자"),
-                fieldWithPath("data[].name").type(JsonFieldType.STRING).description("여행 이름"),
+                fieldWithPath("data[].tripId").type(JsonFieldType.NUMBER).description("여행 식별자"),
+                fieldWithPath("data[].tripName").type(JsonFieldType.STRING).description("여행 이름"),
                 fieldWithPath("data[].startDate").type(JsonFieldType.STRING).description("여행 시작일"),
                 fieldWithPath("data[].endDate").type(JsonFieldType.STRING).description("여행 종료일"),
                 fieldWithPath("data[].isDomestic").type(JsonFieldType.BOOLEAN)
@@ -111,7 +111,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
     @DisplayName("getTripById()는 여행 정보를 조회할 수 있다.")
     void getTripById() throws Exception {
         // given
-        TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+        TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
             .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).build();
         given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
@@ -121,8 +121,8 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                 restDoc.document(pathParameters(parameterWithName("tripId").description("여행 식별자")),
                     responseFields(responseCommon()).and(
                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
-                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("여행 식별자"),
-                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("여행 이름"),
+                        fieldWithPath("data.tripId").type(JsonFieldType.NUMBER).description("여행 식별자"),
+                        fieldWithPath("data.tripName").type(JsonFieldType.STRING).description("여행 이름"),
                         fieldWithPath("data.startDate").type(JsonFieldType.STRING)
                             .description("여행 시작일"),
                         fieldWithPath("data.endDate").type(JsonFieldType.STRING).description("여행 종료일"),
@@ -134,9 +134,9 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
     @DisplayName("updateTrip()은 여행 정보를 수정할 수 있다.")
     void updateTrip() throws Exception {
         // given
-        UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name("울릉도 여행")
+        UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
             .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
-        TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+        TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
             .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).build();
         given(tripService.updateTrip(any(UpdateTripRequestDTO.class))).willReturn(trip);
 
@@ -144,9 +144,9 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         mockMvc.perform(patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andDo(
             restDoc.document(requestFields(
-                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("여행 식별자").attributes(
+                    fieldWithPath("tripId").type(JsonFieldType.NUMBER).description("여행 식별자").attributes(
                         key("constraints").value(updateDescriptions.descriptionsForProperty("id"))),
-                    fieldWithPath("name").type(JsonFieldType.STRING).description("여행 이름").attributes(
+                    fieldWithPath("tripName").type(JsonFieldType.STRING).description("여행 이름").attributes(
                         key("constraints").value(updateDescriptions.descriptionsForProperty("name"))),
                     fieldWithPath("startDate").type(JsonFieldType.STRING).description("여행 시작일")
                         .attributes(key("constraints").value(
@@ -159,8 +159,8 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                             updateDescriptions.descriptionsForProperty("isDomestic")))),
                 responseFields(responseCommon()).and(
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
-                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("여행 식별자"),
-                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("여행 이름"),
+                    fieldWithPath("data.tripId").type(JsonFieldType.NUMBER).description("여행 식별자"),
+                    fieldWithPath("data.tripName").type(JsonFieldType.STRING).description("여행 이름"),
                     fieldWithPath("data.startDate").type(JsonFieldType.STRING)
                         .description("여행 시작일"),
                     fieldWithPath("data.endDate").type(JsonFieldType.STRING).description("여행 종료일"),
@@ -173,7 +173,7 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
     @DisplayName("deleteTripById()은 특정 id를 가진 여행 정보를 삭제할 수 있다.")
     void deleteTripById() throws Exception {
         //given
-        TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+        TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
             .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
         given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 

--- a/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
@@ -56,7 +56,7 @@ public class TripRestControllerTest {
             given(tripService.postTrip(any(PostTripRequestDTO.class))).willReturn(trip);
 
             // when, then
-            mockMvc.perform(post("/api/trip")
+            mockMvc.perform(post("/api/trips")
                     .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
@@ -82,7 +82,7 @@ public class TripRestControllerTest {
                     .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trip")
+                mockMvc.perform(post("/api/trips")
                         .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -102,7 +102,7 @@ public class TripRestControllerTest {
                     .startDate(null).endDate("2023-10-26").isDomestic(true).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trip")
+                mockMvc.perform(post("/api/trips")
                         .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -117,7 +117,7 @@ public class TripRestControllerTest {
                     .startDate(" ").endDate("2023-10-26").isDomestic(true).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trip")
+                mockMvc.perform(post("/api/trips")
                         .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -137,7 +137,7 @@ public class TripRestControllerTest {
                     .startDate("2023-10-26").endDate(null).isDomestic(true).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trip")
+                mockMvc.perform(post("/api/trips")
                         .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -152,7 +152,7 @@ public class TripRestControllerTest {
                     .startDate("2023-10-26").endDate(" ").isDomestic(true).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trip")
+                mockMvc.perform(post("/api/trips")
                         .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -172,7 +172,7 @@ public class TripRestControllerTest {
                     .startDate("2023-10-26").endDate("2023-10-26").isDomestic(null).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trip")
+                mockMvc.perform(post("/api/trips")
                         .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
@@ -199,7 +199,7 @@ public class TripRestControllerTest {
             given(tripService.getTrips()).willReturn(trips);
 
             // when, then
-            mockMvc.perform(get("/api/trip")).andExpect(status().isOk())
+            mockMvc.perform(get("/api/trips")).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[0].tripId").exists())
@@ -224,7 +224,7 @@ public class TripRestControllerTest {
             given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
             // when, then
-            mockMvc.perform(get("/api/trip/{tripId}", 1L)).andExpect(status().isOk())
+            mockMvc.perform(get("/api/trips/{tripId}", 1L)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.tripId").exists())
                 .andExpect(jsonPath("$.data.tripName").exists())
@@ -251,7 +251,7 @@ public class TripRestControllerTest {
 
             // when, then
             mockMvc.perform(
-                    patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                    patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.tripId").exists())
@@ -276,7 +276,7 @@ public class TripRestControllerTest {
 
                 // when, then
                 mockMvc.perform(
-                        patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                        patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).updateTrip(any(UpdateTripRequestDTO.class));
@@ -296,7 +296,7 @@ public class TripRestControllerTest {
 
                 // when, then
                 mockMvc.perform(
-                        patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                        patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).updateTrip(any(UpdateTripRequestDTO.class));
@@ -316,7 +316,7 @@ public class TripRestControllerTest {
 
                 // when, then
                 mockMvc.perform(
-                        patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                        patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).updateTrip(any(UpdateTripRequestDTO.class));
@@ -331,7 +331,7 @@ public class TripRestControllerTest {
 
                 // when, then
                 mockMvc.perform(
-                        patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                        patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).updateTrip(any(UpdateTripRequestDTO.class));
@@ -351,7 +351,7 @@ public class TripRestControllerTest {
 
                 // when, then
                 mockMvc.perform(
-                        patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                        patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).updateTrip(any(UpdateTripRequestDTO.class));
@@ -366,7 +366,7 @@ public class TripRestControllerTest {
 
                 // when, then
                 mockMvc.perform(
-                        patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                        patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).updateTrip(any(UpdateTripRequestDTO.class));
@@ -386,7 +386,7 @@ public class TripRestControllerTest {
 
                 // when, then
                 mockMvc.perform(
-                        patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
+                        patch("/api/trips").content(new ObjectMapper().writeValueAsString(request))
                             .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).updateTrip(any(UpdateTripRequestDTO.class));
@@ -407,7 +407,7 @@ public class TripRestControllerTest {
             given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
             //when, then
-            mockMvc.perform(delete("/api/trip/{tripId}", 1L))
+            mockMvc.perform(delete("/api/trips/{tripId}", 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andDo(print());

--- a/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -52,7 +51,7 @@ public class TripRestControllerTest {
             // given
             PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
                 .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
-            TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+            TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
                 .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
             given(tripService.postTrip(any(PostTripRequestDTO.class))).willReturn(trip);
 
@@ -62,8 +61,8 @@ public class TripRestControllerTest {
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.id").exists())
-                .andExpect(jsonPath("$.data.name").exists())
+                .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.tripId").exists())
+                .andExpect(jsonPath("$.data.tripName").exists())
                 .andExpect(jsonPath("$.data.startDate").exists())
                 .andExpect(jsonPath("$.data.endDate").exists())
                 .andExpect(jsonPath("$.data.isDomestic").exists())
@@ -191,11 +190,11 @@ public class TripRestControllerTest {
         void _willSuccess() throws Exception {
             // given
             List<TripResponseDTO> trips = new ArrayList<>();
-            trips.add(TripResponseDTO.builder().id(1L).name("제주도 여행").startDate("2023-10-23")
+            trips.add(TripResponseDTO.builder().tripId(1L).tripName("제주도 여행").startDate("2023-10-23")
                 .endDate("2023-10-27").isDomestic(true).build());
-            trips.add(TripResponseDTO.builder().id(2L).name("속초 겨울바다 여행").startDate("2023-11-27")
+            trips.add(TripResponseDTO.builder().tripId(2L).tripName("속초 겨울바다 여행").startDate("2023-11-27")
                 .endDate("2023-11-29").isDomestic(true).build());
-            trips.add(TripResponseDTO.builder().id(3L).name("크리스마스 미국 여행").startDate("2023-12-24")
+            trips.add(TripResponseDTO.builder().tripId(3L).tripName("크리스마스 미국 여행").startDate("2023-12-24")
                 .endDate("2023-12-26").isDomestic(false).build());
             given(tripService.getTrips()).willReturn(trips);
 
@@ -203,8 +202,8 @@ public class TripRestControllerTest {
             mockMvc.perform(get("/api/trip")).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].id").exists())
-                .andExpect(jsonPath("$.data[0].name").exists())
+                .andExpect(jsonPath("$.data[0].tripId").exists())
+                .andExpect(jsonPath("$.data[0].tripName").exists())
                 .andExpect(jsonPath("$.data[0].startDate").exists())
                 .andExpect(jsonPath("$.data[0].endDate").exists())
                 .andExpect(jsonPath("$.data[0].isDomestic").exists()).andDo(print());
@@ -220,15 +219,15 @@ public class TripRestControllerTest {
         @DisplayName("여행 정보를 조회할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+            TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
                 .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).build();
             given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
             // when, then
             mockMvc.perform(get("/api/trip/{tripId}", 1L)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.id").exists())
-                .andExpect(jsonPath("$.data.name").exists())
+                .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.tripId").exists())
+                .andExpect(jsonPath("$.data.tripName").exists())
                 .andExpect(jsonPath("$.data.startDate").exists())
                 .andExpect(jsonPath("$.data.endDate").exists())
                 .andExpect(jsonPath("$.data.isDomestic").exists()).andDo(print());
@@ -244,9 +243,9 @@ public class TripRestControllerTest {
         @DisplayName("여행 정보를 수정할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name("울릉도 여행")
+            UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
                 .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
-            TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+            TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
                 .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).build();
             given(tripService.updateTrip(any(UpdateTripRequestDTO.class))).willReturn(trip);
 
@@ -255,8 +254,8 @@ public class TripRestControllerTest {
                     patch("/api/trip").content(new ObjectMapper().writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
-                .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.id").exists())
-                .andExpect(jsonPath("$.data.name").exists())
+                .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.tripId").exists())
+                .andExpect(jsonPath("$.data.tripName").exists())
                 .andExpect(jsonPath("$.data.startDate").exists())
                 .andExpect(jsonPath("$.data.endDate").exists())
                 .andExpect(jsonPath("$.data.isDomestic").exists()).andDo(print());
@@ -271,8 +270,8 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(null)
-                    .name("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26").isDomestic(true)
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(null)
+                    .tripName("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26").isDomestic(true)
                     .build();
 
                 // when, then
@@ -292,7 +291,7 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name(null)
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName(null)
                     .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
 
                 // when, then
@@ -312,7 +311,7 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name("울릉도 여행")
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
                     .startDate(null).endDate("2023-10-26").isDomestic(true).build();
 
                 // when, then
@@ -327,7 +326,7 @@ public class TripRestControllerTest {
             @DisplayName("빈 칸일 경우 여행 정보를 수정할 수 없다.")
             void blank_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name("울릉도 여행")
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
                     .startDate(" ").endDate("2023-10-26").isDomestic(true).build();
 
                 // when, then
@@ -347,7 +346,7 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name("울릉도 여행")
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
                     .startDate("2023-10-25").endDate(null).isDomestic(true).build();
 
                 // when, then
@@ -362,7 +361,7 @@ public class TripRestControllerTest {
             @DisplayName("빈 칸일 경우 여행 정보를 수정할 수 없다.")
             void blank_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name("울릉도 여행")
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
                     .startDate("2023-10-25").endDate(" ").isDomestic(true).build();
 
                 // when, then
@@ -382,7 +381,7 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().id(1L).name("울릉도 여행")
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
                     .startDate("2023-10-25").endDate("2023-10-26").isDomestic(null).build();
 
                 // when, then
@@ -403,7 +402,7 @@ public class TripRestControllerTest {
         @DisplayName("여행 정보를 삭제할 수 있다")
         void _willSuccess() throws Exception {
             //given
-            TripResponseDTO trip = TripResponseDTO.builder().id(1L).name("제주도 여행")
+            TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
                 .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
             given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 

--- a/src/test/java/com/fc/toy_project2/trip/unit/service/TripServiceTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/unit/service/TripServiceTest.java
@@ -65,7 +65,7 @@ public class TripServiceTest {
             TripResponseDTO result = tripService.postTrip(postTripRequestDTO);
 
             // then
-            assertThat(result).extracting("id", "name", "startDate", "endDate", "isDomestic")
+            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate", "isDomestic")
                 .containsExactly(1L, "제주도 여행", "2023-10-25", "2023-10-26", true);
             verify(tripRepository, times(1)).save(any(Trip.class));
         }
@@ -134,7 +134,7 @@ public class TripServiceTest {
             TripResponseDTO result = tripService.getTripById(1L);
 
             // then
-            assertThat(result).extracting("id", "name", "startDate", "endDate", "isDomestic")
+            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate", "isDomestic")
                 .containsExactly(1L, "제주도 여행", "2023-10-23", "2023-10-27", true);
             verify(tripRepository, times(1)).findById(any(Long.TYPE));
         }
@@ -163,8 +163,8 @@ public class TripServiceTest {
         @DisplayName("여행 정보를 수정할 수 있다.")
         void _willSuccess() {
             // given
-            UpdateTripRequestDTO updateTripRequestDTO = UpdateTripRequestDTO.builder().id(1L)
-                .name("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26").isDomestic(true)
+            UpdateTripRequestDTO updateTripRequestDTO = UpdateTripRequestDTO.builder().tripId(1L)
+                .tripName("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26").isDomestic(true)
                 .build();
             Optional<Trip> trip = Optional.of(
                 Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 23))
@@ -176,7 +176,7 @@ public class TripServiceTest {
             TripResponseDTO result = tripService.updateTrip(updateTripRequestDTO);
 
             // then
-            assertThat(result).extracting("id", "name", "startDate", "endDate", "isDomestic")
+            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate", "isDomestic")
                 .containsExactly(1L, "울릉도 여행", "2023-10-25", "2023-10-26", true);
             verify(tripRepository, times(1)).findById(any(Long.TYPE));
         }
@@ -185,8 +185,8 @@ public class TripServiceTest {
         @DisplayName("여행 시작일이 알맞지 않으면 수정할 수 없다.")
         void WrongStartDate_willFail() {
             // given
-            UpdateTripRequestDTO updateTripRequestDTO = UpdateTripRequestDTO.builder().id(1L)
-                .name("울릉도 여행").startDate("2023-10-25").endDate("2023-10-24").isDomestic(true)
+            UpdateTripRequestDTO updateTripRequestDTO = UpdateTripRequestDTO.builder().tripId(1L)
+                .tripName("울릉도 여행").startDate("2023-10-25").endDate("2023-10-24").isDomestic(true)
                 .build();
             Optional<Trip> trip = Optional.of(
                 Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 23))


### PR DESCRIPTION
### 개발 내용
- Trip API 요청 및 응답 DTO 변수명 수정
- 연관된 모든 코드 수정 (테스트 포함)
- Trip API 요청 URI에 단순 유지 규칙을 적용 (trip의 복수형인 trips 사용)