### PR TITLE
여행 조회 시 여정 정보를 포함하여 응답하도록 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -24,7 +24,7 @@ endif::[]
 |===
 | Status code | Useage
 | `200 OK` | 요청을 성공적으로 수행
-| `201 Created` | 생성 요청 (ex: 게시글 생성)을 성공적으로 수행
+| `201 Created` | 생성 요청 (ex: 여행 등록)을 성공적으로 수행
 | `400 Bad Request` | API 에 기술되어 있는 요구사항에 부적합 시 발생
 | `401 Unauthorized` | 해당 API에 대한 인증 정보가 없는 경우 발생
 | `403 Forbiddon` | 해당 API에 대한 권한이 없는 경우 발생

--- a/src/main/java/com/fc/toy_project2/domain/trip/controller/TripRestController.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/controller/TripRestController.java
@@ -2,6 +2,8 @@ package com.fc.toy_project2.domain.trip.controller;
 
 import com.fc.toy_project2.domain.trip.dto.request.PostTripRequestDTO;
 import com.fc.toy_project2.domain.trip.dto.request.UpdateTripRequestDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripsResponseDTO;
 import com.fc.toy_project2.domain.trip.dto.response.TripResponseDTO;
 import com.fc.toy_project2.domain.trip.service.TripService;
 import com.fc.toy_project2.global.DTO.ResponseDTO;
@@ -36,13 +38,13 @@ public class TripRestController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDTO<List<TripResponseDTO>>> getTrips() {
+    public ResponseEntity<ResponseDTO<List<GetTripsResponseDTO>>> getTrips() {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, tripService.getTrips(), "성공적으로 여행 정보 목록을 조회했습니다."));
     }
 
     @GetMapping("/{tripId}")
-    public ResponseEntity<ResponseDTO<TripResponseDTO>> getTripById(@PathVariable long tripId) {
+    public ResponseEntity<ResponseDTO<GetTripResponseDTO>> getTripById(@PathVariable long tripId) {
         return ResponseEntity.status(HttpStatus.OK).body(
             ResponseDTO.res(HttpStatus.OK, tripService.getTripById(tripId),
                 "성공적으로 여행 정보를 조회했습니다."));

--- a/src/main/java/com/fc/toy_project2/domain/trip/dto/response/GetTripResponseDTO.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/dto/response/GetTripResponseDTO.java
@@ -1,0 +1,17 @@
+package com.fc.toy_project2.domain.trip.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetTripResponseDTO {
+
+    private Long tripId;
+    private String tripName;
+    private String startDate;
+    private String endDate;
+    private Boolean isDomestic;
+    private List<Object> itineraries;
+}

--- a/src/main/java/com/fc/toy_project2/domain/trip/dto/response/GetTripsResponseDTO.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/dto/response/GetTripsResponseDTO.java
@@ -1,0 +1,17 @@
+package com.fc.toy_project2.domain.trip.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetTripsResponseDTO {
+
+    private Long tripId;
+    private String tripName;
+    private String startDate;
+    private String endDate;
+    private Boolean isDomestic;
+    private List<ItineraryInfoDTO> itineraries;
+}

--- a/src/main/java/com/fc/toy_project2/domain/trip/dto/response/ItineraryInfoDTO.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/dto/response/ItineraryInfoDTO.java
@@ -1,0 +1,12 @@
+package com.fc.toy_project2.domain.trip.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItineraryInfoDTO {
+
+    private Long itineraryId;
+    private String itineraryName;
+}

--- a/src/main/java/com/fc/toy_project2/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/entity/Trip.java
@@ -1,7 +1,6 @@
 package com.fc.toy_project2.domain.trip.entity;
 
 import com.fc.toy_project2.domain.itinerary.dto.response.AccommodationResponseDTO;
-import com.fc.toy_project2.domain.itinerary.dto.response.ItinerarySearchResponseDTO;
 import com.fc.toy_project2.domain.itinerary.dto.response.TransportationResponseDTO;
 import com.fc.toy_project2.domain.itinerary.entity.Itinerary;
 import com.fc.toy_project2.domain.trip.dto.request.UpdateTripRequestDTO;
@@ -112,53 +111,38 @@ public class Trip {
     public List<ItineraryInfoDTO> getItineraryInfoDTO() {
         List<ItineraryInfoDTO> itineraries = new ArrayList<>();
         for (Itinerary itinerary : this.itineraries) {
-            //TODO itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
-            //                    .itineraryName(itinerary.getAccommodationName()).build()); 로 수정
-            if (itinerary.getType() == 0) {
-                itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
-                    .itineraryName(itinerary.getAccommodationName()).build());
-            } else if (itinerary.getType() == 1) {
-                itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
-                    .itineraryName(itinerary.getTransportation()).build());
-            } else if (itinerary.getType() == 2) {
-                itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
-                    .itineraryName(itinerary.getPlaceName()).build());
-            }
+            itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
+                .itineraryName(itinerary.getItineraryName()).build());
         }
         return itineraries;
     }
 
-    public List<Object> getItineraryResponseDTO(){
+    public List<Object> getItineraryResponseDTO() {
         List<Object> itineraryList = new ArrayList<>();
         for (Itinerary itinerary : this.itineraries) {
-            //TODO itineraryName도 추가
             if (itinerary.getType() == 0) {
-                itineraryList.add(AccommodationResponseDTO.builder()
-                    .itineraryId(itinerary.getId())
+                itineraryList.add(AccommodationResponseDTO.builder().itineraryId(itinerary.getId())
+                    .itineraryName(itinerary.getItineraryName())
                     .accommodationName(itinerary.getAccommodationName())
-                    .accommodationRoadAddressName(
-                        itinerary.getAccommodationRoadAddressName())
+                    .accommodationRoadAddressName(itinerary.getAccommodationRoadAddressName())
                     .checkIn(localDateTimeToString(itinerary.getCheckIn()))
-                    .checkOut(localDateTimeToString(itinerary.getCheckOut()))
-                    .build());
+                    .checkOut(localDateTimeToString(itinerary.getCheckOut())).build());
             } else if (itinerary.getType() == 1) {
-                itineraryList.add(TransportationResponseDTO.builder()
-                    .itineraryId(itinerary.getId())
+                itineraryList.add(TransportationResponseDTO.builder().itineraryId(itinerary.getId())
+                    .itineraryName(itinerary.getItineraryName())
                     .transportation(itinerary.getTransportation())
                     .departurePlace(itinerary.getDeparturePlace())
-                    .departurePlaceRoadAddressName(
-                        itinerary.getDeparturePlaceRoadAddressName())
+                    .departurePlaceRoadAddressName(itinerary.getDeparturePlaceRoadAddressName())
                     .destination(itinerary.getDestination())
                     .destinationRoadAddressName(itinerary.getDestinationRoadAddressName())
                     .departureTime(localDateTimeToString(itinerary.getDepartureTime()))
                     .arrivalTime(localDateTimeToString(itinerary.getArrivalTime())).build());
             } else if (itinerary.getType() == 2) {
-                itineraryList.add(TransportationResponseDTO.builder()
-                    .itineraryId(itinerary.getId())
+                itineraryList.add(TransportationResponseDTO.builder().itineraryId(itinerary.getId())
+                    .itineraryName(itinerary.getItineraryName())
                     .transportation(itinerary.getTransportation())
                     .departurePlace(itinerary.getDeparturePlace())
-                    .departurePlaceRoadAddressName(
-                        itinerary.getDeparturePlaceRoadAddressName())
+                    .departurePlaceRoadAddressName(itinerary.getDeparturePlaceRoadAddressName())
                     .destination(itinerary.getDestination())
                     .destinationRoadAddressName(itinerary.getDestinationRoadAddressName())
                     .departureTime(localDateTimeToString(itinerary.getDepartureTime()))

--- a/src/main/java/com/fc/toy_project2/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/entity/Trip.java
@@ -1,7 +1,13 @@
 package com.fc.toy_project2.domain.trip.entity;
 
+import com.fc.toy_project2.domain.itinerary.dto.response.AccommodationResponseDTO;
+import com.fc.toy_project2.domain.itinerary.dto.response.ItinerarySearchResponseDTO;
+import com.fc.toy_project2.domain.itinerary.dto.response.TransportationResponseDTO;
 import com.fc.toy_project2.domain.itinerary.entity.Itinerary;
 import com.fc.toy_project2.domain.trip.dto.request.UpdateTripRequestDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripsResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.ItineraryInfoDTO;
 import com.fc.toy_project2.domain.trip.dto.response.TripResponseDTO;
 import com.fc.toy_project2.global.util.DateTypeFormatterUtil;
 import jakarta.persistence.CascadeType;
@@ -11,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,6 +83,92 @@ public class Trip {
     }
 
     /**
+     * Trip Entity를 GetTripsResponseDTO로 변환
+     *
+     * @return GetTripsResponseDTO
+     */
+    public GetTripsResponseDTO toGetTripsResponseDTO() {
+        return GetTripsResponseDTO.builder().tripId(this.id).tripName(this.name)
+            .startDate(localDateToString(this.startDate)).endDate(localDateToString(this.endDate))
+            .isDomestic(this.isDomestic).itineraries(getItineraryInfoDTO()).build();
+    }
+
+    /**
+     * Trip Entity를 GetTripsResponseDTO로 변환
+     *
+     * @return GetTripsResponseDTO
+     */
+    public GetTripResponseDTO toGetTripResponseDTO() {
+        return GetTripResponseDTO.builder().tripId(this.id).tripName(this.name)
+            .startDate(localDateToString(this.startDate)).endDate(localDateToString(this.endDate))
+            .isDomestic(this.isDomestic).itineraries(getItineraryResponseDTO()).build();
+    }
+
+    /**
+     * Itinerary ID와 Name를 담은 ItineraryInfoDTO 추출
+     *
+     * @return ItineraryInfoDTO 리스트
+     */
+    public List<ItineraryInfoDTO> getItineraryInfoDTO() {
+        List<ItineraryInfoDTO> itineraries = new ArrayList<>();
+        for (Itinerary itinerary : this.itineraries) {
+            //TODO itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
+            //                    .itineraryName(itinerary.getAccommodationName()).build()); 로 수정
+            if (itinerary.getType() == 0) {
+                itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
+                    .itineraryName(itinerary.getAccommodationName()).build());
+            } else if (itinerary.getType() == 1) {
+                itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
+                    .itineraryName(itinerary.getTransportation()).build());
+            } else if (itinerary.getType() == 2) {
+                itineraries.add(ItineraryInfoDTO.builder().itineraryId(itinerary.getId())
+                    .itineraryName(itinerary.getPlaceName()).build());
+            }
+        }
+        return itineraries;
+    }
+
+    public List<Object> getItineraryResponseDTO(){
+        List<Object> itineraryList = new ArrayList<>();
+        for (Itinerary itinerary : this.itineraries) {
+            //TODO itineraryName도 추가
+            if (itinerary.getType() == 0) {
+                itineraryList.add(AccommodationResponseDTO.builder()
+                    .itineraryId(itinerary.getId())
+                    .accommodationName(itinerary.getAccommodationName())
+                    .accommodationRoadAddressName(
+                        itinerary.getAccommodationRoadAddressName())
+                    .checkIn(localDateTimeToString(itinerary.getCheckIn()))
+                    .checkOut(localDateTimeToString(itinerary.getCheckOut()))
+                    .build());
+            } else if (itinerary.getType() == 1) {
+                itineraryList.add(TransportationResponseDTO.builder()
+                    .itineraryId(itinerary.getId())
+                    .transportation(itinerary.getTransportation())
+                    .departurePlace(itinerary.getDeparturePlace())
+                    .departurePlaceRoadAddressName(
+                        itinerary.getDeparturePlaceRoadAddressName())
+                    .destination(itinerary.getDestination())
+                    .destinationRoadAddressName(itinerary.getDestinationRoadAddressName())
+                    .departureTime(localDateTimeToString(itinerary.getDepartureTime()))
+                    .arrivalTime(localDateTimeToString(itinerary.getArrivalTime())).build());
+            } else if (itinerary.getType() == 2) {
+                itineraryList.add(TransportationResponseDTO.builder()
+                    .itineraryId(itinerary.getId())
+                    .transportation(itinerary.getTransportation())
+                    .departurePlace(itinerary.getDeparturePlace())
+                    .departurePlaceRoadAddressName(
+                        itinerary.getDeparturePlaceRoadAddressName())
+                    .destination(itinerary.getDestination())
+                    .destinationRoadAddressName(itinerary.getDestinationRoadAddressName())
+                    .departureTime(localDateTimeToString(itinerary.getDepartureTime()))
+                    .arrivalTime(localDateTimeToString(itinerary.getArrivalTime())).build());
+            }
+        }
+        return itineraryList;
+    }
+
+    /**
      * 여행 정보를 수정
      *
      * @param updateTripRequestDTO 여행 정보 수정 요청 DTO
@@ -95,5 +188,15 @@ public class Trip {
      */
     private String localDateToString(LocalDate date) {
         return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    /**
+     * LocalDateTime 타입을 String 타입으로 변환
+     *
+     * @param date LocalDateTime 타입의 날짜
+     * @return String 타입의 날짜
+     */
+    private String localDateTimeToString(LocalDateTime date) {
+        return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
     }
 }

--- a/src/main/java/com/fc/toy_project2/domain/trip/service/TripService.java
+++ b/src/main/java/com/fc/toy_project2/domain/trip/service/TripService.java
@@ -3,6 +3,8 @@ package com.fc.toy_project2.domain.trip.service;
 import com.fc.toy_project2.domain.itinerary.entity.Itinerary;
 import com.fc.toy_project2.domain.trip.dto.request.PostTripRequestDTO;
 import com.fc.toy_project2.domain.trip.dto.request.UpdateTripRequestDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripsResponseDTO;
 import com.fc.toy_project2.domain.trip.dto.response.TripResponseDTO;
 import com.fc.toy_project2.domain.trip.entity.Trip;
 import com.fc.toy_project2.domain.trip.exception.InvalidTripDateRangeException;
@@ -58,11 +60,11 @@ public class TripService {
      *
      * @return 여행 정보 응답 DTO 리스트
      */
-    public List<TripResponseDTO> getTrips() {
-        List<TripResponseDTO> trips = new ArrayList<>();
+    public List<GetTripsResponseDTO> getTrips() {
+        List<GetTripsResponseDTO> trips = new ArrayList<>();
         List<Trip> tripList = tripRepository.findAll(Sort.by(Direction.ASC, "id"));
         for (Trip trip : tripList) {
-            trips.add(trip.toTripResponseDTO());
+            trips.add(trip.toGetTripsResponseDTO());
         }
         return trips;
     }
@@ -73,8 +75,8 @@ public class TripService {
      * @param id 조회할 하는 여행 ID
      * @return 여행 정보 응답 DTO
      */
-    public TripResponseDTO getTripById(Long id) {
-        return getTrip(id).toTripResponseDTO();
+    public GetTripResponseDTO getTripById(Long id) {
+        return getTrip(id).toGetTripResponseDTO();
     }
 
     public TripResponseDTO updateTrip(UpdateTripRequestDTO updateTripRequestDTO) {

--- a/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
@@ -2,6 +2,7 @@ package com.fc.toy_project2.trip.docs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -15,9 +16,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.toy_project2.domain.itinerary.dto.response.AccommodationResponseDTO;
+import com.fc.toy_project2.domain.itinerary.dto.response.TransportationResponseDTO;
+import com.fc.toy_project2.domain.itinerary.dto.response.VisitResponseDTO;
 import com.fc.toy_project2.domain.trip.controller.TripRestController;
 import com.fc.toy_project2.domain.trip.dto.request.PostTripRequestDTO;
 import com.fc.toy_project2.domain.trip.dto.request.UpdateTripRequestDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripsResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.ItineraryInfoDTO;
 import com.fc.toy_project2.domain.trip.dto.response.TripResponseDTO;
 import com.fc.toy_project2.domain.trip.service.TripService;
 import com.fc.toy_project2.util.RestDocsSupport;
@@ -44,9 +51,11 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         return new TripRestController(tripService);
     }
 
-    private final ConstraintDescriptions postDescriptions = new ConstraintDescriptions(PostTripRequestDTO.class);
+    private final ConstraintDescriptions postDescriptions = new ConstraintDescriptions(
+        PostTripRequestDTO.class);
 
-    private final ConstraintDescriptions updateDescriptions = new ConstraintDescriptions(UpdateTripRequestDTO.class);
+    private final ConstraintDescriptions updateDescriptions = new ConstraintDescriptions(
+        UpdateTripRequestDTO.class);
 
     @Test
     @DisplayName("postTrip()은 여행 정보를 저장할 수 있다.")
@@ -60,25 +69,30 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
 
         // when, then
         mockMvc.perform(RestDocumentationRequestBuilders.post("/api/trips")
-                .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated()).andDo(restDoc.document(
-                requestFields(
+            .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated()).andDo(
+            restDoc.document(requestFields(
                     fieldWithPath("tripName").type(JsonFieldType.STRING).description("여행 이름")
-                        .attributes(key("constraints").value(postDescriptions.descriptionsForProperty("tripName"))),
+                        .attributes(key("constraints").value(
+                            postDescriptions.descriptionsForProperty("tripName"))),
                     fieldWithPath("startDate").type(JsonFieldType.STRING).description("여행 시작일")
-                        .attributes(key("constraints").value(postDescriptions.descriptionsForProperty("startDate"))),
+                        .attributes(key("constraints").value(
+                            postDescriptions.descriptionsForProperty("startDate"))),
                     fieldWithPath("endDate").type(JsonFieldType.STRING).description("여행 종료일")
-                        .attributes(key("constraints").value(postDescriptions.descriptionsForProperty("endDate"))),
+                        .attributes(key("constraints").value(
+                            postDescriptions.descriptionsForProperty("endDate"))),
                     fieldWithPath("isDomestic").type(JsonFieldType.BOOLEAN).description("국내 여행 여부")
-                        .attributes(key("constraints").value(postDescriptions.descriptionsForProperty("isDomestic")))),
+                        .attributes(key("constraints").value(
+                            postDescriptions.descriptionsForProperty("isDomestic")))),
                 responseFields(responseCommon()).and(
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
                     fieldWithPath("data.tripId").type(JsonFieldType.NUMBER).description("여행 식별자"),
                     fieldWithPath("data.tripName").type(JsonFieldType.STRING).description("여행 이름"),
-                    fieldWithPath("data.startDate").type(JsonFieldType.STRING).description("여행 시작일"),
+                    fieldWithPath("data.startDate").type(JsonFieldType.STRING)
+                        .description("여행 시작일"),
                     fieldWithPath("data.endDate").type(JsonFieldType.STRING).description("여행 종료일"),
-                    fieldWithPath("data.isDomestic").type(JsonFieldType.BOOLEAN).description("국내 여행 여부"))));
+                    fieldWithPath("data.isDomestic").type(JsonFieldType.BOOLEAN)
+                        .description("국내 여행 여부"))));
         verify(tripService, times(1)).postTrip((any(PostTripRequestDTO.class)));
     }
 
@@ -86,13 +100,31 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
     @DisplayName("getTrips()은 여행 정보 목록을 조회할 수 있다.")
     void getTrips() throws Exception {
         // given
-        List<TripResponseDTO> trips = new ArrayList<>();
-        trips.add(TripResponseDTO.builder().tripId(1L).tripName("제주도 여행").startDate("2023-10-23")
-            .endDate("2023-10-27").isDomestic(true).build());
-        trips.add(TripResponseDTO.builder().tripId(2L).tripName("속초 겨울바다 여행").startDate("2023-11-27")
-            .endDate("2023-11-29").isDomestic(true).build());
-        trips.add(TripResponseDTO.builder().tripId(3L).tripName("크리스마스 미국 여행").startDate("2023-12-24")
-            .endDate("2023-12-26").isDomestic(false).build());
+        List<ItineraryInfoDTO> itineraries1 = new ArrayList<>();
+        itineraries1.add(
+            ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("제주 신라 호텔에서 숙박!").build());
+        itineraries1.add(ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("카카오 택시타고 이동!").build());
+        itineraries1.add(ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("카멜리아힐 구경!").build());
+        List<ItineraryInfoDTO> itineraries2 = new ArrayList<>();
+        itineraries2.add(ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("속초 호텔에서 숙면!").build());
+        itineraries2.add(ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("버스타고 이동!").build());
+        itineraries2.add(
+            ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("속초 해수욕장에서 놀기!").build());
+        List<ItineraryInfoDTO> itineraries3 = new ArrayList<>();
+        itineraries3.add(ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("뉴욕 호텔에서 꿀잠!").build());
+        itineraries3.add(ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("지하철타고 이동").build());
+        itineraries3.add(
+            ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("뉴욕 유명 거리 걷기").build());
+        List<GetTripsResponseDTO> trips = new ArrayList<>();
+        trips.add(
+            GetTripsResponseDTO.builder().tripId(1L).tripName("제주도 여행").startDate("2023-10-23")
+                .endDate("2023-10-27").isDomestic(true).itineraries(itineraries1).build());
+        trips.add(
+            GetTripsResponseDTO.builder().tripId(2L).tripName("속초 겨울바다 여행").startDate("2023-11-27")
+                .endDate("2023-11-29").isDomestic(true).itineraries(itineraries2).build());
+        trips.add(
+            GetTripsResponseDTO.builder().tripId(3L).tripName("크리스마스 미국 여행").startDate("2023-12-24")
+                .endDate("2023-12-26").isDomestic(false).itineraries(itineraries3).build());
         given(tripService.getTrips()).willReturn(trips);
 
         // when, then
@@ -104,15 +136,35 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                 fieldWithPath("data[].startDate").type(JsonFieldType.STRING).description("여행 시작일"),
                 fieldWithPath("data[].endDate").type(JsonFieldType.STRING).description("여행 종료일"),
                 fieldWithPath("data[].isDomestic").type(JsonFieldType.BOOLEAN)
-                    .description("국내 여행 여부"))));
+                    .description("국내 여행 여부"),
+                fieldWithPath("data[].itineraries").optional().type(JsonFieldType.ARRAY)
+                    .description("여정 리스트"),
+                fieldWithPath("data[].itineraries[].itineraryId").optional().type(JsonFieldType.NUMBER)
+                    .description("여정 식별자"),
+                fieldWithPath("data[].itineraries[].itineraryName").optional().type(JsonFieldType.STRING)
+                    .description("여정 이름"))));
     }
 
     @Test
     @DisplayName("getTripById()는 여행 정보를 조회할 수 있다.")
     void getTripById() throws Exception {
         // given
-        TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
-            .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).build();
+        List<Object> itineraries = new ArrayList<>();
+        itineraries.add(
+            //TODO itineraryName 추가
+            AccommodationResponseDTO.builder().itineraryId(1L).accommodationName("제주신라호텔")
+                .accommodationRoadAddressName("제주 서귀포시 중문관광로72번길 75").checkIn("2023-10-25 15:00")
+                .checkOut("2023-10-26 11:00").build());
+        itineraries.add(TransportationResponseDTO.builder().itineraryId(2L).transportation("카카오택시")
+            .departurePlace("제주신라호텔").departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75")
+            .destination("오설록 티 뮤지엄").destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
+            .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
+        itineraries.add(VisitResponseDTO.builder().itineraryId(3L).placeName("카멜리아힐")
+            .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
+            .arrivalTime("2023-10-26 16:00").build());
+        GetTripResponseDTO trip = GetTripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
+            .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).itineraries(itineraries)
+            .build();
         given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
         // when, then
@@ -127,7 +179,40 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                             .description("여행 시작일"),
                         fieldWithPath("data.endDate").type(JsonFieldType.STRING).description("여행 종료일"),
                         fieldWithPath("data.isDomestic").type(JsonFieldType.BOOLEAN)
-                            .description("국내 여행 여부"))));
+                            .description("국내 여행 여부"),
+                        fieldWithPath("data.itineraries").type(JsonFieldType.ARRAY).optional().description("여정 리스트"),
+                        fieldWithPath("data.itineraries[].itineraryId").type(JsonFieldType.NUMBER)
+                            .optional().description("여정 식별자"),
+                        fieldWithPath("data.itineraries[].accommodationName").type(JsonFieldType.STRING)
+                            .optional().description("숙소명"),
+                        fieldWithPath("data.itineraries[].accommodationRoadAddressName").type(
+                            JsonFieldType.STRING).optional().description("숙소 도로명"),
+                        fieldWithPath("data.itineraries[].checkIn").type(JsonFieldType.STRING)
+                            .optional().description("체크인 일시"),
+                        fieldWithPath("data.itineraries[].checkOut").type(JsonFieldType.STRING)
+                            .optional().description("체크아웃 일시"),
+                        fieldWithPath("data.itineraries[].transportation").type(JsonFieldType.STRING)
+                            .optional().description("이동 수단"),
+                        fieldWithPath("data.itineraries[].departurePlace").type(JsonFieldType.STRING)
+                            .optional().description("출발지"),
+                        fieldWithPath("data.itineraries[].departurePlaceRoadAddressName").type(
+                            JsonFieldType.STRING).optional().description("출발지 도로명"),
+                        fieldWithPath("data.itineraries[].destination").type(JsonFieldType.STRING)
+                            .optional().description("도착지"),
+                        fieldWithPath("data.itineraries[].destinationRoadAddressName").type(
+                            JsonFieldType.STRING).optional().description("도착지 도로명"),
+                        fieldWithPath("data.itineraries[].departureTime").type(JsonFieldType.STRING)
+                            .optional().description("출발 일시"),
+                        fieldWithPath("data.itineraries[].arrivalTime").type(JsonFieldType.STRING)
+                            .optional().description("도착 일시"),
+                        fieldWithPath("data.itineraries[].placeName").type(JsonFieldType.STRING)
+                            .optional().description("장소명"),
+                        fieldWithPath("data.itineraries[].placeRoadAddressName").type(
+                            JsonFieldType.STRING).optional().description("장소 도로명"),
+                        fieldWithPath("data.itineraries[].departureTime").type(JsonFieldType.STRING)
+                            .optional().description("도착 일시"),
+                        fieldWithPath("data.itineraries[].arrivalTime").type(JsonFieldType.STRING)
+                            .optional().description("출발 일시"))));
     }
 
     @Test
@@ -146,8 +231,9 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
             restDoc.document(requestFields(
                     fieldWithPath("tripId").type(JsonFieldType.NUMBER).description("여행 식별자").attributes(
                         key("constraints").value(updateDescriptions.descriptionsForProperty("id"))),
-                    fieldWithPath("tripName").type(JsonFieldType.STRING).description("여행 이름").attributes(
-                        key("constraints").value(updateDescriptions.descriptionsForProperty("name"))),
+                    fieldWithPath("tripName").type(JsonFieldType.STRING).description("여행 이름")
+                        .attributes(key("constraints").value(
+                            updateDescriptions.descriptionsForProperty("name"))),
                     fieldWithPath("startDate").type(JsonFieldType.STRING).description("여행 시작일")
                         .attributes(key("constraints").value(
                             updateDescriptions.descriptionsForProperty("startDate"))),
@@ -173,15 +259,14 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
     @DisplayName("deleteTripById()은 특정 id를 가진 여행 정보를 삭제할 수 있다.")
     void deleteTripById() throws Exception {
         //given
-        TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
-            .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
-        given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
+        doNothing().when(tripService).deleteTripById(any(Long.TYPE));
 
         //when, then
         mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/trips/{tripId}", 1L))
-            .andExpect(status().isOk()).andDo(restDoc.document(
-                pathParameters(parameterWithName("tripId").description("여행 식별자")),
-                responseFields(responseCommon()).and(fieldWithPath("data").type(null).description("응답데이터 없음"))));
+            .andExpect(status().isOk()).andDo(
+                restDoc.document(pathParameters(parameterWithName("tripId").description("여행 식별자")),
+                    responseFields(responseCommon()).and(
+                        fieldWithPath("data").type(null).description("응답데이터 없음"))));
         verify(tripService, times(1)).deleteTripById(any(Long.TYPE));
     }
 }

--- a/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
@@ -103,16 +103,22 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         List<ItineraryInfoDTO> itineraries1 = new ArrayList<>();
         itineraries1.add(
             ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("제주 신라 호텔에서 숙박!").build());
-        itineraries1.add(ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("카카오 택시타고 이동!").build());
-        itineraries1.add(ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("카멜리아힐 구경!").build());
+        itineraries1.add(
+            ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("카카오 택시타고 이동!").build());
+        itineraries1.add(
+            ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("카멜리아힐 구경!").build());
         List<ItineraryInfoDTO> itineraries2 = new ArrayList<>();
-        itineraries2.add(ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("속초 호텔에서 숙면!").build());
-        itineraries2.add(ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("버스타고 이동!").build());
+        itineraries2.add(
+            ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("속초 호텔에서 숙면!").build());
+        itineraries2.add(
+            ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("버스타고 이동!").build());
         itineraries2.add(
             ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("속초 해수욕장에서 놀기!").build());
         List<ItineraryInfoDTO> itineraries3 = new ArrayList<>();
-        itineraries3.add(ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("뉴욕 호텔에서 꿀잠!").build());
-        itineraries3.add(ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("지하철타고 이동").build());
+        itineraries3.add(
+            ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("뉴욕 호텔에서 꿀잠!").build());
+        itineraries3.add(
+            ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("지하철타고 이동").build());
         itineraries3.add(
             ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("뉴욕 유명 거리 걷기").build());
         List<GetTripsResponseDTO> trips = new ArrayList<>();
@@ -139,10 +145,10 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                     .description("국내 여행 여부"),
                 fieldWithPath("data[].itineraries").optional().type(JsonFieldType.ARRAY)
                     .description("여정 리스트"),
-                fieldWithPath("data[].itineraries[].itineraryId").optional().type(JsonFieldType.NUMBER)
-                    .description("여정 식별자"),
-                fieldWithPath("data[].itineraries[].itineraryName").optional().type(JsonFieldType.STRING)
-                    .description("여정 이름"))));
+                fieldWithPath("data[].itineraries[].itineraryId").optional()
+                    .type(JsonFieldType.NUMBER).description("여정 식별자"),
+                fieldWithPath("data[].itineraries[].itineraryName").optional()
+                    .type(JsonFieldType.STRING).description("여정 이름"))));
     }
 
     @Test
@@ -151,17 +157,19 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
         // given
         List<Object> itineraries = new ArrayList<>();
         itineraries.add(
-            //TODO itineraryName 추가
-            AccommodationResponseDTO.builder().itineraryId(1L).accommodationName("제주신라호텔")
-                .accommodationRoadAddressName("제주 서귀포시 중문관광로72번길 75").checkIn("2023-10-25 15:00")
-                .checkOut("2023-10-26 11:00").build());
-        itineraries.add(TransportationResponseDTO.builder().itineraryId(2L).transportation("카카오택시")
-            .departurePlace("제주신라호텔").departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75")
-            .destination("오설록 티 뮤지엄").destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
-            .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
-        itineraries.add(VisitResponseDTO.builder().itineraryId(3L).placeName("카멜리아힐")
-            .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-            .arrivalTime("2023-10-26 16:00").build());
+            AccommodationResponseDTO.builder().itineraryId(1L).itineraryName("제주 신라 호텔에서 숙박!")
+                .accommodationName("제주신라호텔").accommodationRoadAddressName("제주 서귀포시 중문관광로72번길 75")
+                .checkIn("2023-10-25 15:00").checkOut("2023-10-26 11:00").build());
+        itineraries.add(
+            TransportationResponseDTO.builder().itineraryId(2L).itineraryName("카카오 택시타고 이동!")
+                .transportation("카카오택시").departurePlace("제주신라호텔")
+                .departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75").destination("오설록 티 뮤지엄")
+                .destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
+                .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
+        itineraries.add(
+            VisitResponseDTO.builder().itineraryId(3L).itineraryName("카멜리아힐 구경!").placeName("카멜리아힐")
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
+                .arrivalTime("2023-10-26 16:00").build());
         GetTripResponseDTO trip = GetTripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
             .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).itineraries(itineraries)
             .build();
@@ -180,7 +188,8 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                         fieldWithPath("data.endDate").type(JsonFieldType.STRING).description("여행 종료일"),
                         fieldWithPath("data.isDomestic").type(JsonFieldType.BOOLEAN)
                             .description("국내 여행 여부"),
-                        fieldWithPath("data.itineraries").type(JsonFieldType.ARRAY).optional().description("여정 리스트"),
+                        fieldWithPath("data.itineraries").type(JsonFieldType.ARRAY).optional()
+                            .description("여정 리스트"),
                         fieldWithPath("data.itineraries[].itineraryId").type(JsonFieldType.NUMBER)
                             .optional().description("여정 식별자"),
                         fieldWithPath("data.itineraries[].accommodationName").type(JsonFieldType.STRING)

--- a/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/docs/TripRestControllerDocsTest.java
@@ -192,6 +192,8 @@ public class TripRestControllerDocsTest extends RestDocsSupport {
                             .description("여정 리스트"),
                         fieldWithPath("data.itineraries[].itineraryId").type(JsonFieldType.NUMBER)
                             .optional().description("여정 식별자"),
+                        fieldWithPath("data.itineraries[].itineraryName").type(JsonFieldType.STRING)
+                            .optional().description("여정 이름"),
                         fieldWithPath("data.itineraries[].accommodationName").type(JsonFieldType.STRING)
                             .optional().description("숙소명"),
                         fieldWithPath("data.itineraries[].accommodationRoadAddressName").type(

--- a/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
@@ -243,19 +243,20 @@ public class TripRestControllerTest {
         void _willSuccess() throws Exception {
             // given
             List<Object> itineraries = new ArrayList<>();
-            //TODO itineraryName 추가
             itineraries.add(
-                AccommodationResponseDTO.builder().itineraryId(1L).accommodationName("제주신라호텔")
+                AccommodationResponseDTO.builder().itineraryId(1L).itineraryName("제주 신라 호텔에서 숙박!")
+                    .accommodationName("제주신라호텔")
                     .accommodationRoadAddressName("제주 서귀포시 중문관광로72번길 75")
                     .checkIn("2023-10-25 15:00").checkOut("2023-10-26 11:00").build());
             itineraries.add(
-                TransportationResponseDTO.builder().itineraryId(2L).transportation("카카오택시")
-                    .departurePlace("제주신라호텔").departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75")
-                    .destination("오설록 티 뮤지엄").destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
+                TransportationResponseDTO.builder().itineraryId(2L).itineraryName("카카오 택시타고 이동!")
+                    .transportation("카카오택시").departurePlace("제주신라호텔")
+                    .departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75").destination("오설록 티 뮤지엄")
+                    .destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
                     .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
-            itineraries.add(VisitResponseDTO.builder().itineraryId(3L).placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26, 16:00").build());
+            itineraries.add(VisitResponseDTO.builder().itineraryId(3L).itineraryName("카멜리아힐 구경!")
+                .placeName("카멜리아힐").placeRoadAddressName("제주 서귀포시 안덕면 병악로 166")
+                .departureTime("2023-10-26 14:00").arrivalTime("2023-10-26, 16:00").build());
             GetTripResponseDTO trip = GetTripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
                 .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true)
                 .itineraries(itineraries).build();

--- a/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/unit/controller/TripRestControllerTest.java
@@ -14,11 +14,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fc.toy_project2.domain.itinerary.dto.response.AccommodationResponseDTO;
+import com.fc.toy_project2.domain.itinerary.dto.response.TransportationResponseDTO;
+import com.fc.toy_project2.domain.itinerary.dto.response.VisitResponseDTO;
+import com.fc.toy_project2.domain.itinerary.entity.Itinerary;
 import com.fc.toy_project2.domain.trip.controller.TripRestController;
 import com.fc.toy_project2.domain.trip.dto.request.PostTripRequestDTO;
 import com.fc.toy_project2.domain.trip.dto.request.UpdateTripRequestDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripsResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.ItineraryInfoDTO;
 import com.fc.toy_project2.domain.trip.dto.response.TripResponseDTO;
+import com.fc.toy_project2.domain.trip.entity.Trip;
 import com.fc.toy_project2.domain.trip.service.TripService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +55,7 @@ public class TripRestControllerTest {
     @Nested
     @DisplayName("postTrip()은")
     class Context_postTrip {
+
         @Test
         @DisplayName("여행정보를 저장할 수 있다.")
         void _willSuccess() throws Exception {
@@ -56,17 +67,15 @@ public class TripRestControllerTest {
             given(tripService.postTrip(any(PostTripRequestDTO.class))).willReturn(trip);
 
             // when, then
-            mockMvc.perform(post("/api/trips")
-                    .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
+            mockMvc.perform(post("/api/trips").content(
+                        new ObjectMapper().writeValueAsString(postTripRequestDTO))
+                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.data").isMap()).andExpect(jsonPath("$.data.tripId").exists())
                 .andExpect(jsonPath("$.data.tripName").exists())
                 .andExpect(jsonPath("$.data.startDate").exists())
                 .andExpect(jsonPath("$.data.endDate").exists())
-                .andExpect(jsonPath("$.data.isDomestic").exists())
-                .andDo(print());
+                .andExpect(jsonPath("$.data.isDomestic").exists()).andDo(print());
             verify(tripService, times(1)).postTrip((any(PostTripRequestDTO.class)));
         }
 
@@ -82,8 +91,8 @@ public class TripRestControllerTest {
                     .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trips")
-                        .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
+                mockMvc.perform(post("/api/trips").content(
+                            new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).postTrip(any(PostTripRequestDTO.class));
@@ -98,12 +107,13 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 저장할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
-                    .startDate(null).endDate("2023-10-26").isDomestic(true).build();
+                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder()
+                    .tripName("제주도 여행").startDate(null).endDate("2023-10-26").isDomestic(true)
+                    .build();
 
                 // when, then
-                mockMvc.perform(post("/api/trips")
-                        .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
+                mockMvc.perform(post("/api/trips").content(
+                            new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).postTrip(any(PostTripRequestDTO.class));
@@ -113,12 +123,13 @@ public class TripRestControllerTest {
             @DisplayName("빈 칸일 경우 여행 정보를 저장할 수 없다.")
             void blank_willFail() throws Exception {
                 // given
-                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
-                    .startDate(" ").endDate("2023-10-26").isDomestic(true).build();
+                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder()
+                    .tripName("제주도 여행").startDate(" ").endDate("2023-10-26").isDomestic(true)
+                    .build();
 
                 // when, then
-                mockMvc.perform(post("/api/trips")
-                        .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
+                mockMvc.perform(post("/api/trips").content(
+                            new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).postTrip(any(PostTripRequestDTO.class));
@@ -133,12 +144,13 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 저장할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
-                    .startDate("2023-10-26").endDate(null).isDomestic(true).build();
+                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder()
+                    .tripName("제주도 여행").startDate("2023-10-26").endDate(null).isDomestic(true)
+                    .build();
 
                 // when, then
-                mockMvc.perform(post("/api/trips")
-                        .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
+                mockMvc.perform(post("/api/trips").content(
+                            new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).postTrip(any(PostTripRequestDTO.class));
@@ -148,12 +160,13 @@ public class TripRestControllerTest {
             @DisplayName("빈 칸일 경우 여행 정보를 저장할 수 없다.")
             void blank_willFail() throws Exception {
                 // given
-                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
-                    .startDate("2023-10-26").endDate(" ").isDomestic(true).build();
+                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder()
+                    .tripName("제주도 여행").startDate("2023-10-26").endDate(" ").isDomestic(true)
+                    .build();
 
                 // when, then
-                mockMvc.perform(post("/api/trips")
-                        .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
+                mockMvc.perform(post("/api/trips").content(
+                            new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).postTrip(any(PostTripRequestDTO.class));
@@ -168,12 +181,13 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 저장할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
-                    .startDate("2023-10-26").endDate("2023-10-26").isDomestic(null).build();
+                PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder()
+                    .tripName("제주도 여행").startDate("2023-10-26").endDate("2023-10-26")
+                    .isDomestic(null).build();
 
                 // when, then
-                mockMvc.perform(post("/api/trips")
-                        .content(new ObjectMapper().writeValueAsString(postTripRequestDTO))
+                mockMvc.perform(post("/api/trips").content(
+                            new ObjectMapper().writeValueAsString(postTripRequestDTO))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
                     .andDo(print());
                 verify(tripService, never()).postTrip(any(PostTripRequestDTO.class));
@@ -189,13 +203,21 @@ public class TripRestControllerTest {
         @DisplayName("여행 정보 목록을 조회할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            List<TripResponseDTO> trips = new ArrayList<>();
-            trips.add(TripResponseDTO.builder().tripId(1L).tripName("제주도 여행").startDate("2023-10-23")
-                .endDate("2023-10-27").isDomestic(true).build());
-            trips.add(TripResponseDTO.builder().tripId(2L).tripName("속초 겨울바다 여행").startDate("2023-11-27")
-                .endDate("2023-11-29").isDomestic(true).build());
-            trips.add(TripResponseDTO.builder().tripId(3L).tripName("크리스마스 미국 여행").startDate("2023-12-24")
-                .endDate("2023-12-26").isDomestic(false).build());
+            List<ItineraryInfoDTO> itineraries = new ArrayList<>();
+            itineraries.add(
+                ItineraryInfoDTO.builder().itineraryId(1L).itineraryName("제주 신라 호텔에서 숙박!").build());
+            itineraries.add(
+                ItineraryInfoDTO.builder().itineraryId(2L).itineraryName("카카오 택시타고 이동!").build());
+            itineraries.add(
+                ItineraryInfoDTO.builder().itineraryId(3L).itineraryName("카멜리아힐 구경!").build());
+            List<GetTripsResponseDTO> trips = new ArrayList<>();
+            trips.add(
+                GetTripsResponseDTO.builder().tripId(1L).tripName("제주도 여행").startDate("2023-10-23")
+                    .endDate("2023-10-27").isDomestic(true).itineraries(itineraries).build());
+            trips.add(GetTripsResponseDTO.builder().tripId(2L).tripName("속초 겨울바다 여행")
+                .startDate("2023-11-27").endDate("2023-11-29").isDomestic(true).build());
+            trips.add(GetTripsResponseDTO.builder().tripId(3L).tripName("크리스마스 미국 여행")
+                .startDate("2023-12-24").endDate("2023-12-26").isDomestic(false).build());
             given(tripService.getTrips()).willReturn(trips);
 
             // when, then
@@ -206,7 +228,8 @@ public class TripRestControllerTest {
                 .andExpect(jsonPath("$.data[0].tripName").exists())
                 .andExpect(jsonPath("$.data[0].startDate").exists())
                 .andExpect(jsonPath("$.data[0].endDate").exists())
-                .andExpect(jsonPath("$.data[0].isDomestic").exists()).andDo(print());
+                .andExpect(jsonPath("$.data[0].isDomestic").exists())
+                .andExpect(jsonPath("$.data[0].itineraries").exists()).andDo(print());
             verify(tripService, times(1)).getTrips();
         }
     }
@@ -219,8 +242,23 @@ public class TripRestControllerTest {
         @DisplayName("여행 정보를 조회할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
-                .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).build();
+            List<Object> itineraries = new ArrayList<>();
+            //TODO itineraryName 추가
+            itineraries.add(
+                AccommodationResponseDTO.builder().itineraryId(1L).accommodationName("제주신라호텔")
+                    .accommodationRoadAddressName("제주 서귀포시 중문관광로72번길 75")
+                    .checkIn("2023-10-25 15:00").checkOut("2023-10-26 11:00").build());
+            itineraries.add(
+                TransportationResponseDTO.builder().itineraryId(2L).transportation("카카오택시")
+                    .departurePlace("제주신라호텔").departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75")
+                    .destination("오설록 티 뮤지엄").destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
+                    .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
+            itineraries.add(VisitResponseDTO.builder().itineraryId(3L).placeName("카멜리아힐")
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
+                .arrivalTime("2023-10-26, 16:00").build());
+            GetTripResponseDTO trip = GetTripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
+                .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true)
+                .itineraries(itineraries).build();
             given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
 
             // when, then
@@ -230,7 +268,8 @@ public class TripRestControllerTest {
                 .andExpect(jsonPath("$.data.tripName").exists())
                 .andExpect(jsonPath("$.data.startDate").exists())
                 .andExpect(jsonPath("$.data.endDate").exists())
-                .andExpect(jsonPath("$.data.isDomestic").exists()).andDo(print());
+                .andExpect(jsonPath("$.data.isDomestic").exists())
+                .andExpect(jsonPath("$.data.itineraries").exists()).andDo(print());
             verify(tripService, times(1)).getTripById(any(Long.TYPE));
         }
     }
@@ -243,8 +282,9 @@ public class TripRestControllerTest {
         @DisplayName("여행 정보를 수정할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
-                .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
+            UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L)
+                .tripName("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26").isDomestic(true)
+                .build();
             TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
                 .startDate("2023-10-23").endDate("2023-10-27").isDomestic(true).build();
             given(tripService.updateTrip(any(UpdateTripRequestDTO.class))).willReturn(trip);
@@ -271,8 +311,8 @@ public class TripRestControllerTest {
             void null_willFail() throws Exception {
                 // given
                 UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(null)
-                    .tripName("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26").isDomestic(true)
-                    .build();
+                    .tripName("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26")
+                    .isDomestic(true).build();
 
                 // when, then
                 mockMvc.perform(
@@ -291,8 +331,9 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName(null)
-                    .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L)
+                    .tripName(null).startDate("2023-10-25").endDate("2023-10-26").isDomestic(true)
+                    .build();
 
                 // when, then
                 mockMvc.perform(
@@ -311,8 +352,9 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
-                    .startDate(null).endDate("2023-10-26").isDomestic(true).build();
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L)
+                    .tripName("울릉도 여행").startDate(null).endDate("2023-10-26").isDomestic(true)
+                    .build();
 
                 // when, then
                 mockMvc.perform(
@@ -326,8 +368,9 @@ public class TripRestControllerTest {
             @DisplayName("빈 칸일 경우 여행 정보를 수정할 수 없다.")
             void blank_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
-                    .startDate(" ").endDate("2023-10-26").isDomestic(true).build();
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L)
+                    .tripName("울릉도 여행").startDate(" ").endDate("2023-10-26").isDomestic(true)
+                    .build();
 
                 // when, then
                 mockMvc.perform(
@@ -346,8 +389,9 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
-                    .startDate("2023-10-25").endDate(null).isDomestic(true).build();
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L)
+                    .tripName("울릉도 여행").startDate("2023-10-25").endDate(null).isDomestic(true)
+                    .build();
 
                 // when, then
                 mockMvc.perform(
@@ -361,8 +405,9 @@ public class TripRestControllerTest {
             @DisplayName("빈 칸일 경우 여행 정보를 수정할 수 없다.")
             void blank_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
-                    .startDate("2023-10-25").endDate(" ").isDomestic(true).build();
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L)
+                    .tripName("울릉도 여행").startDate("2023-10-25").endDate(" ").isDomestic(true)
+                    .build();
 
                 // when, then
                 mockMvc.perform(
@@ -381,8 +426,9 @@ public class TripRestControllerTest {
             @DisplayName("null일 경우 여행 정보를 수정할 수 없다.")
             void null_willFail() throws Exception {
                 // given
-                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L).tripName("울릉도 여행")
-                    .startDate("2023-10-25").endDate("2023-10-26").isDomestic(null).build();
+                UpdateTripRequestDTO request = UpdateTripRequestDTO.builder().tripId(1L)
+                    .tripName("울릉도 여행").startDate("2023-10-25").endDate("2023-10-26")
+                    .isDomestic(null).build();
 
                 // when, then
                 mockMvc.perform(
@@ -402,13 +448,28 @@ public class TripRestControllerTest {
         @DisplayName("여행 정보를 삭제할 수 있다")
         void _willSuccess() throws Exception {
             //given
-            TripResponseDTO trip = TripResponseDTO.builder().tripId(1L).tripName("제주도 여행")
-                .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
-            given(tripService.getTripById(any(Long.TYPE))).willReturn(trip);
+            List<Itinerary> itineraries = new ArrayList<>();
+            itineraries.add(Itinerary.builder().id(1L).accommodationName("제주신라호텔")
+                .accommodationRoadAddressName("제주 서귀포시 중문관광로72번길 75")
+                .checkIn(LocalDateTime.of(2023, 10, 25, 15, 0))
+                .checkOut(LocalDateTime.of(2023, 10, 26, 11, 0)).build());
+            itineraries.add(
+                Itinerary.builder().id(2L).transportation("카카오택시").departurePlace("제주신라호텔")
+                    .departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75").destination("오설록 티 뮤지엄")
+                    .destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
+                    .departureTime(LocalDateTime.of(2023, 10, 26, 12, 0))
+                    .arrivalTime(LocalDateTime.of(2023, 10, 26, 13, 0)).build());
+            itineraries.add(Itinerary.builder().id(3L).placeName("카멜리아힐")
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166")
+                .departureTime(LocalDateTime.of(2023, 10, 26, 14, 0))
+                .arrivalTime(LocalDateTime.of(2023, 10, 26, 16, 0)).build());
+            Trip trip = Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 23))
+                .endDate(LocalDate.of(2023, 10, 27)).isDomestic(true).itineraries(itineraries)
+                .build();
+            given(tripService.getTrip(any(Long.TYPE))).willReturn(trip);
 
             //when, then
-            mockMvc.perform(delete("/api/trips/{tripId}", 1L))
-                .andExpect(status().isOk())
+            mockMvc.perform(delete("/api/trips/{tripId}", 1L)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists()).andExpect(jsonPath("$.message").exists())
                 .andDo(print());
             verify(tripService, times(1)).deleteTripById(any(Long.TYPE));

--- a/src/test/java/com/fc/toy_project2/trip/unit/service/TripServiceTest.java
+++ b/src/test/java/com/fc/toy_project2/trip/unit/service/TripServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.verify;
 
 import com.fc.toy_project2.domain.trip.dto.request.PostTripRequestDTO;
 import com.fc.toy_project2.domain.trip.dto.request.UpdateTripRequestDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripResponseDTO;
+import com.fc.toy_project2.domain.trip.dto.response.GetTripsResponseDTO;
 import com.fc.toy_project2.domain.trip.dto.response.TripResponseDTO;
 import com.fc.toy_project2.domain.trip.entity.Trip;
 import com.fc.toy_project2.domain.trip.exception.InvalidTripDateRangeException;
@@ -57,16 +59,16 @@ public class TripServiceTest {
             PostTripRequestDTO postTripRequestDTO = PostTripRequestDTO.builder().tripName("제주도 여행")
                 .startDate("2023-10-25").endDate("2023-10-26").isDomestic(true).build();
             Trip trip = Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 25))
-                    .endDate(LocalDate.of(2023, 10, 26)).isDomestic(true)
-                    .itineraries(new ArrayList<>()).build();
+                .endDate(LocalDate.of(2023, 10, 26)).isDomestic(true).itineraries(new ArrayList<>())
+                .build();
             given(tripRepository.save(any(Trip.class))).willReturn(trip);
 
             // when
             TripResponseDTO result = tripService.postTrip(postTripRequestDTO);
 
             // then
-            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate", "isDomestic")
-                .containsExactly(1L, "제주도 여행", "2023-10-25", "2023-10-26", true);
+            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate",
+                "isDomestic").containsExactly(1L, "제주도 여행", "2023-10-25", "2023-10-26", true);
             verify(tripRepository, times(1)).save(any(Trip.class));
         }
 
@@ -108,7 +110,7 @@ public class TripServiceTest {
             given(tripRepository.findAll(Sort.by(Direction.ASC, "id"))).willReturn(trips);
 
             // when
-            List<TripResponseDTO> result = tripService.getTrips();
+            List<GetTripsResponseDTO> result = tripService.getTrips();
 
             // then
             assertThat(result).isNotEmpty();
@@ -131,11 +133,11 @@ public class TripServiceTest {
             given(tripRepository.findById(any(Long.TYPE))).willReturn(trip);
 
             // when
-            TripResponseDTO result = tripService.getTripById(1L);
+            GetTripResponseDTO result = tripService.getTripById(1L);
 
             // then
-            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate", "isDomestic")
-                .containsExactly(1L, "제주도 여행", "2023-10-23", "2023-10-27", true);
+            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate",
+                "isDomestic").containsExactly(1L, "제주도 여행", "2023-10-23", "2023-10-27", true);
             verify(tripRepository, times(1)).findById(any(Long.TYPE));
         }
 
@@ -176,8 +178,8 @@ public class TripServiceTest {
             TripResponseDTO result = tripService.updateTrip(updateTripRequestDTO);
 
             // then
-            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate", "isDomestic")
-                .containsExactly(1L, "울릉도 여행", "2023-10-25", "2023-10-26", true);
+            assertThat(result).extracting("tripId", "tripName", "startDate", "endDate",
+                "isDomestic").containsExactly(1L, "울릉도 여행", "2023-10-25", "2023-10-26", true);
             verify(tripRepository, times(1)).findById(any(Long.TYPE));
         }
 
@@ -212,8 +214,8 @@ public class TripServiceTest {
         void _willSuccess() {
             // given
             Trip trip = Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 25))
-                    .endDate(LocalDate.of(2023, 10, 26)).isDomestic(true)
-                    .itineraries(new ArrayList<>()).build();
+                .endDate(LocalDate.of(2023, 10, 26)).isDomestic(true).itineraries(new ArrayList<>())
+                .build();
             given(tripRepository.findById(any(Long.TYPE))).willReturn(Optional.of(trip));
 
             // when


### PR DESCRIPTION
### 개발 내용
RFP 을 재차 확인하던 중 여행 목록 조회에서 여정 이름을, 특정 여행 목록 조회에서는 여정의 상세 정보를 보여줘야 한다는 부분을 보고 수정했습니다. 

- 여행 목록 조회 시 여정 ID와 이름을 포함하여 응답하도록 수정
  - 여정 ID와 이름을 필드로 갖는 DTO 구현
  - 여행 목록 조회 응답 DTO 구현
  - 서비스, 컨트롤러 수정
  - 테스트 코드 수정
- 특정 여행 조회 시 여정의 모든 상세 정보를 포함하여 응답하도록 수정
  - 특정 여행 조회 응답 DTO 구현
  - 서비스, 컨트롤러 수정
  - 테스트 코드 수정
- index.adoc 수정