### PR TITLE
여정 등록, 조회, 수정 수정

### DIFF
--- a/src/main/java/com/fc/toy_project2/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fc/toy_project2/domain/itinerary/service/ItineraryService.java
@@ -97,21 +97,22 @@ public class ItineraryService {
     /**
      * 숙박과 관련된 여정을 생성합니다.
      *
-     * @param itineraryAccommodationCreateDTO 숙박 여정 생성 요청 DTO
+     * @param accommodationCreateRequestDTO 숙박 여정 생성 요청 DTO
      * @return 생성된 숙박 여정 응답 DTO
      */
     public AccommodationResponseDTO createAccommodation(
-        AccommodationCreateRequestDTO itineraryAccommodationCreateDTO) {
-        Trip trip = tripService.getTrip(itineraryAccommodationCreateDTO.getTripId());
+        AccommodationCreateRequestDTO accommodationCreateRequestDTO) {
+        Trip trip = tripService.getTrip(accommodationCreateRequestDTO.getTripId());
         LocalDateTime checkIn = DateTypeFormatterUtil.dateTimeFormatter(
-            itineraryAccommodationCreateDTO.getCheckIn());
+            accommodationCreateRequestDTO.getCheckIn());
         LocalDateTime checkOut = DateTypeFormatterUtil.dateTimeFormatter(
-            itineraryAccommodationCreateDTO.getCheckOut());
+            accommodationCreateRequestDTO.getCheckOut());
         checkAccommodationDate(trip, checkIn, checkOut);
-        return itineraryRepository.save(Itinerary.builder().trip(trip).type(0) // 숙박 여정 유형
-            .accommodationName(itineraryAccommodationCreateDTO.getAccommodationName())
+        return itineraryRepository.save(Itinerary.builder().trip(trip).type(0)
+                .itineraryName(accommodationCreateRequestDTO.getItineraryName())
+            .accommodationName(accommodationCreateRequestDTO.getAccommodationName())
             .accommodationRoadAddressName(
-                itineraryAccommodationCreateDTO.getAccommodationRoadAddressName()).checkIn(checkIn)
+                accommodationCreateRequestDTO.getAccommodationRoadAddressName()).checkIn(checkIn)
             .checkOut(checkOut).build()).toAccommodationResponseDTO();
     }
 
@@ -128,8 +129,9 @@ public class ItineraryService {
             transportationCreateRequestDTO.getDepartureTime());
         LocalDateTime arrivalTime = DateTypeFormatterUtil.dateTimeFormatter(
             transportationCreateRequestDTO.getArrivalTime());
-        checkTransportationVisitDate(trip, departureTime, arrivalTime);
+        checkTransportationDate(trip, departureTime, arrivalTime);
         return itineraryRepository.save(Itinerary.builder().trip(trip).type(1)
+                .itineraryName(transportationCreateRequestDTO.getItineraryName())
                 .transportation(transportationCreateRequestDTO.getTransportation())
                 .departurePlace(transportationCreateRequestDTO.getDeparturePlace())
                 .departurePlaceRoadAddressName(
@@ -149,15 +151,16 @@ public class ItineraryService {
      */
     public VisitResponseDTO createVisit(VisitCreateRequestDTO visitCreateRequestDTO) {
         Trip trip = tripService.getTrip(visitCreateRequestDTO.getTripId());
-        LocalDateTime visitDepartureTime = DateTypeFormatterUtil.dateTimeFormatter(
+        LocalDateTime departureTime = DateTypeFormatterUtil.dateTimeFormatter(
             visitCreateRequestDTO.getDepartureTime());
-        LocalDateTime visitArrivalTime = DateTypeFormatterUtil.dateTimeFormatter(
+        LocalDateTime arrivalTime = DateTypeFormatterUtil.dateTimeFormatter(
             visitCreateRequestDTO.getArrivalTime());
-        checkTransportationVisitDate(trip, visitDepartureTime, visitArrivalTime);
-        return itineraryRepository.save(
-                Itinerary.builder().trip(trip).type(1).placeName(visitCreateRequestDTO.getPlaceName())
-                    .placeRoadAddressName(visitCreateRequestDTO.getPlaceRoadAddressName())
-                    .arrivalTime(visitArrivalTime).departureTime(visitDepartureTime).build())
+        checkVisitDate(trip, departureTime, arrivalTime);
+        return itineraryRepository.save(Itinerary.builder().trip(trip).type(1)
+                .itineraryName(visitCreateRequestDTO.getItineraryName())
+                .placeName(visitCreateRequestDTO.getPlaceName())
+                .placeRoadAddressName(visitCreateRequestDTO.getPlaceRoadAddressName())
+                .arrivalTime(arrivalTime).departureTime(departureTime).build())
             .toVisitResponseDTO();
     }
 
@@ -169,7 +172,7 @@ public class ItineraryService {
      */
     public List getItineraryByTripId(Long tripId) {
         List<Object> itineraryResponseList = new ArrayList<>();
-        List<Itinerary> itineraryList = itineraryRepository.findAllByTripId(tripId);
+        List<Itinerary> itineraryList = tripService.getTrip(tripId).getItineraries();
         for (Itinerary itinerary : itineraryList) {
             if (itinerary.getType() == 0) {
                 itineraryResponseList.add(
@@ -246,7 +249,7 @@ public class ItineraryService {
             transportationUpdateRequestDTO.getDepartureTime());
         LocalDateTime arrivalTime = DateTypeFormatterUtil.dateTimeFormatter(
             transportationUpdateRequestDTO.getArrivalTime());
-        checkTransportationVisitDate(itinerary.getTrip(), departureTime, arrivalTime);
+        checkTransportationDate(itinerary.getTrip(), departureTime, arrivalTime);
         itinerary.updateTransportationInfo(transportationUpdateRequestDTO.getItineraryName(),
             transportationUpdateRequestDTO.getTransportation(),
             transportationUpdateRequestDTO.getDeparturePlace(),
@@ -269,7 +272,7 @@ public class ItineraryService {
             visitUpdateRequestDTO.getDepartureTime());
         LocalDateTime arrivalTime = DateTypeFormatterUtil.dateTimeFormatter(
             visitUpdateRequestDTO.getArrivalTime());
-        checkTransportationVisitDate(itinerary.getTrip(), departureTime, arrivalTime);
+        checkVisitDate(itinerary.getTrip(), departureTime, arrivalTime);
         itinerary.updateVisitInfo(visitUpdateRequestDTO.getItineraryName(),
             visitUpdateRequestDTO.getPlaceName(), visitUpdateRequestDTO.getPlaceRoadAddressName(),
             departureTime, arrivalTime);
@@ -296,29 +299,6 @@ public class ItineraryService {
     }
 
     /**
-     * 체류 및 이동에 관한 날짜 유효성 검사
-     *
-     * @param trip          여정이 속한 여행
-     * @param departureTime 출발 시간
-     * @param arrivalTime   도착 시간
-     * @throws InvalidItineraryException 날짜 유효성 검사 실패 시 발생
-     */
-    private void checkTransportationVisitDate(Trip trip, LocalDateTime departureTime,
-        LocalDateTime arrivalTime) {
-        LocalDateTime tripStartDateTime = trip.getStartDate().atStartOfDay();
-        LocalDateTime tripEndDateTime = trip.getEndDate().atTime(LocalTime.MAX);
-        if (departureTime.isAfter(arrivalTime)) {
-            throw new InvalidItineraryException("출발 시간은 도착 시간보다 이른 시간이어야 합니다.");
-        }
-        if (departureTime.isAfter(tripEndDateTime)) {
-            throw new InvalidItineraryException("출발 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
-        }
-        if (arrivalTime.isBefore(tripStartDateTime)) {
-            throw new InvalidItineraryException("도착 시간은 여행 시작일보다 빠른 시간이어야 합니다.");
-        }
-    }
-
-    /**
      * 숙박 여정의 날짜 유효성 검사
      *
      * @param trip     여정이 속한 여행
@@ -337,6 +317,52 @@ public class ItineraryService {
         }
         if (checkOut.isBefore(tripStartDateTime)) {
             throw new InvalidItineraryException("체크아웃 시간은 여헹 시작일보다 빠른 시간이어야 합니다.");
+        }
+    }
+
+    /**
+     * 이동에 관한 날짜 유효성 검사
+     *
+     * @param trip          여정이 속한 여행
+     * @param departureTime 출발 시간
+     * @param arrivalTime   도착 시간
+     * @throws InvalidItineraryException 날짜 유효성 검사 실패 시 발생
+     */
+    private void checkTransportationDate(Trip trip, LocalDateTime departureTime,
+        LocalDateTime arrivalTime) {
+        LocalDateTime tripStartDateTime = trip.getStartDate().atStartOfDay();
+        LocalDateTime tripEndDateTime = trip.getEndDate().atTime(LocalTime.MAX);
+        if (departureTime.isAfter(arrivalTime)) {
+            throw new InvalidItineraryException("출발 시간은 도착 시간보다 이른 시간이어야 합니다.");
+        }
+        if (departureTime.isAfter(tripEndDateTime)) {
+            throw new InvalidItineraryException("출발 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
+        }
+        if (arrivalTime.isBefore(tripStartDateTime)) {
+            throw new InvalidItineraryException("도착 시간은 여행 시작일보다 빠른 시간이어야 합니다.");
+        }
+    }
+
+    /**
+     * 체류에 관한 날짜 유효성 검사
+     *
+     * @param trip          여정이 속한 여행
+     * @param departureTime 출발 시간
+     * @param arrivalTime   도착 시간
+     * @throws InvalidItineraryException 날짜 유효성 검사 실패 시 발생
+     */
+    private void checkVisitDate(Trip trip, LocalDateTime departureTime,
+        LocalDateTime arrivalTime) {
+        LocalDateTime tripStartDateTime = trip.getStartDate().atStartOfDay();
+        LocalDateTime tripEndDateTime = trip.getEndDate().atTime(LocalTime.MAX);
+        if (departureTime.isBefore(arrivalTime)) {
+            throw new InvalidItineraryException("도착 시간은 출발 시간보다 이른 시간이어야 합니다.");
+        }
+        if (arrivalTime.isAfter(tripStartDateTime)) {
+            throw new InvalidItineraryException("도착 시간은 여행 시작일보다 빠른 시간이어야 합니다.");
+        }
+        if (departureTime.isBefore(tripEndDateTime)) {
+            throw new InvalidItineraryException("출발 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
         }
     }
 }

--- a/src/main/java/com/fc/toy_project2/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fc/toy_project2/domain/itinerary/service/ItineraryService.java
@@ -312,11 +312,14 @@ public class ItineraryService {
         if (checkIn.isAfter(checkOut)) {
             throw new InvalidItineraryException("체크인 시간은 체크아웃 시간보다 이른 시간이어야 합니다.");
         }
+        if (checkIn.isBefore(tripStartDateTime)) {
+            throw new InvalidItineraryException("체크인 시간은 여행 시작일 이후여야 합니다.");
+        }
         if (checkIn.isAfter(tripEndDateTime)) {
             throw new InvalidItineraryException("체크인 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
         }
-        if (checkOut.isBefore(tripStartDateTime)) {
-            throw new InvalidItineraryException("체크아웃 시간은 여헹 시작일보다 빠른 시간이어야 합니다.");
+        if (checkOut.isAfter(tripEndDateTime)) {
+            throw new InvalidItineraryException("체크아웃 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
         }
     }
 
@@ -335,11 +338,14 @@ public class ItineraryService {
         if (departureTime.isAfter(arrivalTime)) {
             throw new InvalidItineraryException("출발 시간은 도착 시간보다 이른 시간이어야 합니다.");
         }
+        if(departureTime.isBefore(tripStartDateTime)){
+            throw new InvalidItineraryException("출발 시간은 여행 시작일 이후여야 합니다.");
+        }
         if (departureTime.isAfter(tripEndDateTime)) {
             throw new InvalidItineraryException("출발 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
         }
-        if (arrivalTime.isBefore(tripStartDateTime)) {
-            throw new InvalidItineraryException("도착 시간은 여행 시작일보다 빠른 시간이어야 합니다.");
+        if(arrivalTime.isAfter(tripEndDateTime)){
+            throw new InvalidItineraryException("도착 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
         }
     }
 
@@ -355,13 +361,16 @@ public class ItineraryService {
         LocalDateTime arrivalTime) {
         LocalDateTime tripStartDateTime = trip.getStartDate().atStartOfDay();
         LocalDateTime tripEndDateTime = trip.getEndDate().atTime(LocalTime.MAX);
-        if (departureTime.isBefore(arrivalTime)) {
+        if (arrivalTime.isAfter(departureTime)) {
             throw new InvalidItineraryException("도착 시간은 출발 시간보다 이른 시간이어야 합니다.");
         }
-        if (arrivalTime.isAfter(tripStartDateTime)) {
-            throw new InvalidItineraryException("도착 시간은 여행 시작일보다 빠른 시간이어야 합니다.");
+        if (arrivalTime.isBefore(tripStartDateTime)) {
+            throw new InvalidItineraryException("도착 시간은 여행 시작일 이후여야 합니다.");
         }
-        if (departureTime.isBefore(tripEndDateTime)) {
+        if(arrivalTime.isAfter(tripEndDateTime)){
+            throw new InvalidItineraryException("도착 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
+        }
+        if (departureTime.isAfter(tripEndDateTime)) {
             throw new InvalidItineraryException("출발 시간은 여행 종료일보다 빠른 시간이어야 합니다.");
         }
     }

--- a/src/test/java/com/fc/toy_project2/itinerary/docs/ItineraryRestControllerDocsTest.java
+++ b/src/test/java/com/fc/toy_project2/itinerary/docs/ItineraryRestControllerDocsTest.java
@@ -176,10 +176,10 @@ public class ItineraryRestControllerDocsTest extends RestDocsSupport {
         // given
         VisitCreateRequestDTO request = VisitCreateRequestDTO.builder().tripId(1L)
             .itineraryName("제주여정3").placeName("카멜리아힐").placeRoadAddressName("제주 서귀포시 안덕면 병악로 166")
-            .departureTime("2023-10-26 14:00").arrivalTime("2023-10-26 16:00").build();
+            .arrivalTime("2023-10-26 14:00").departureTime("2023-10-26 16:00").build();
         VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder().itineraryId(1L)
             .itineraryName("제주여정3").placeName("카멜리아힐").placeRoadAddressName("제주 서귀포시 안덕면 병악로 166")
-            .departureTime("2023-10-26 14:00").arrivalTime("2023-10-26 16:00").build();
+            .arrivalTime("2023-10-26 14:00").departureTime("2023-10-26 16:00").build();
         given(itineraryService.createVisit(any(VisitCreateRequestDTO.class))).willReturn(
             visitResponseDTO);
 
@@ -222,8 +222,8 @@ public class ItineraryRestControllerDocsTest extends RestDocsSupport {
             .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
         itinerarys.add(
             VisitResponseDTO.builder().itineraryId(3L).itineraryName("제주여정3").placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26 16:00").build());
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                .departureTime("2023-10-26 16:00").build());
 
         given(itineraryService.getItineraryByTripId(any(Long.TYPE))).willReturn(itinerarys);
 
@@ -364,12 +364,12 @@ public class ItineraryRestControllerDocsTest extends RestDocsSupport {
     void updateVisit() throws Exception {
         VisitUpdateRequestDTO request = VisitUpdateRequestDTO.builder().itineraryId(1L)
             .itineraryName("즐거운 제주여정3").placeName("카멜리아힐")
-            .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-            .arrivalTime("2023-10-26 16:00").build();
+            .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+            .departureTime("2023-10-26 16:00").build();
         VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder().itineraryId(1L)
             .itineraryName("즐거운 제주여정3").placeName("카멜리아힐")
-            .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-            .arrivalTime("2023-10-26 16:00").build();
+            .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+            .departureTime("2023-10-26 16:00").build();
         given(itineraryService.updateVisit(any(VisitUpdateRequestDTO.class))).willReturn(
             visitResponseDTO);
 

--- a/src/test/java/com/fc/toy_project2/itinerary/unit/controller/ItineraryRestControllerTest.java
+++ b/src/test/java/com/fc/toy_project2/itinerary/unit/controller/ItineraryRestControllerTest.java
@@ -167,12 +167,12 @@ public class ItineraryRestControllerTest {
             // given
             VisitCreateRequestDTO request = VisitCreateRequestDTO.builder().tripId(1L)
                 .itineraryName("제주여정3").placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26 16:00").build();
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                .departureTime("2023-10-26 16:00").build();
             VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder().itineraryId(1L)
                 .itineraryName("제주여정3").placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26 16:00").build();
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                .departureTime("2023-10-26 16:00").build();
             given(itineraryService.createVisit(any(VisitCreateRequestDTO.class))).willReturn(
                 visitResponseDTO);
 
@@ -212,8 +212,8 @@ public class ItineraryRestControllerTest {
                     .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
             itinerarys.add(
                 VisitResponseDTO.builder().itineraryId(3L).itineraryName("제주여정3").placeName("카멜리아힐")
-                    .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                    .arrivalTime("2023-10-26 16:00").build());
+                    .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                    .departureTime("2023-10-26 16:00").build());
 
             given(itineraryService.getItineraryByTripId(any(Long.TYPE))).willReturn(itinerarys);
 
@@ -312,12 +312,12 @@ public class ItineraryRestControllerTest {
         void _willSuccess() throws Exception {
             VisitUpdateRequestDTO request = VisitUpdateRequestDTO.builder().itineraryId(1L)
                 .itineraryName("즐거운 제주여정3").placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26 16:00").build();
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                .departureTime("2023-10-26 16:00").build();
             VisitResponseDTO visitResponseDTO = VisitResponseDTO.builder().itineraryId(1L)
                 .itineraryName("즐거운 제주여정3").placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26 16:00").build();
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                .departureTime("2023-10-26 16:00").build();
             given(itineraryService.updateVisit(any(VisitUpdateRequestDTO.class))).willReturn(
                 visitResponseDTO);
 

--- a/src/test/java/com/fc/toy_project2/itinerary/unit/service/ItineraryServiceTest.java
+++ b/src/test/java/com/fc/toy_project2/itinerary/unit/service/ItineraryServiceTest.java
@@ -133,8 +133,8 @@ public class ItineraryServiceTest {
             // given
             VisitCreateRequestDTO visitCreateRequestDTO = VisitCreateRequestDTO.builder().tripId(1L)
                 .itineraryName("제주여정3").placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26 16:00").build();
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                .departureTime("2023-10-26 16:00").build();
             given(tripService.getTrip(any(Long.TYPE))).willReturn(
                 Trip.builder().id(1L).name("제주도 여행").startDate(LocalDate.of(2023, 10, 25))
                     .endDate(LocalDate.of(2023, 10, 26)).isDomestic(true)
@@ -142,15 +142,15 @@ public class ItineraryServiceTest {
             given(itineraryRepository.save(any(Itinerary.class))).willReturn(
                 Itinerary.builder().id(3L).itineraryName("제주여정3").placeName("카멜리아힐")
                     .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166")
-                    .departureTime(LocalDateTime.of(2023, 10, 26, 14, 0))
-                    .arrivalTime(LocalDateTime.of(2023, 10, 26, 16, 0)).build());
+                    .arrivalTime(LocalDateTime.of(2023, 10, 26, 14, 0))
+                    .departureTime(LocalDateTime.of(2023, 10, 26, 16, 0)).build());
 
             // when
             VisitResponseDTO result = itineraryService.createVisit(visitCreateRequestDTO);
 
             // then
             assertThat(result).extracting("itineraryName", "placeName", "placeRoadAddressName",
-                    "departureTime", "arrivalTime")
+                    "arrivalTime", "departureTime")
                 .containsExactly("제주여정3", "카멜리아힐", "제주 서귀포시 안덕면 병악로 166", "2023-10-26 14:00",
                     "2023-10-26 16:00");
             verify(itineraryRepository, times(1)).save(any(Itinerary.class));
@@ -179,29 +179,15 @@ public class ItineraryServiceTest {
 
             Itinerary visit = Itinerary.builder().id(3L).type(2).itineraryName("제주여정2")
                 .placeName("카멜리아힐").placeRoadAddressName("제주 서귀포시 안덕면 병악로 166")
-                .departureTime(LocalDateTime.of(2023, 10, 26, 14, 0))
-                .arrivalTime(LocalDateTime.of(2023, 10, 26, 16, 0)).build();
+                .arrivalTime(LocalDateTime.of(2023, 10, 26, 14, 0))
+                .departureTime(LocalDateTime.of(2023, 10, 26, 16, 0)).build();
 
             List<Itinerary> itineraryList = new ArrayList<>();
             itineraryList.add(accommodation);
             itineraryList.add(transportation);
             itineraryList.add(visit);
-
-            List<Object> itinerarys = new ArrayList<>();
-            itinerarys.add(AccommodationResponseDTO.builder().itineraryId(1L).itineraryName("제주여정1")
-                .accommodationName("제주신라호텔").accommodationRoadAddressName("제주 서귀포시 중문관광로72번길 75")
-                .checkIn("2023-10-25 15:00").checkOut("2023-10-26 11:00").build());
-            itinerarys.add(
-                TransportationResponseDTO.builder().itineraryId(2L).itineraryName("제주여정2")
-                    .transportation("카카오택시").departurePlace("제주신라호텔")
-                    .departurePlaceRoadAddressName("제주 서귀포시 중문관광로72번길 75").destination("오설록 티 뮤지엄")
-                    .destinationRoadAddressName("제주 서귀포시 안덕면 신화역사로 15 오설록")
-                    .departureTime("2023-10-26 12:00").arrivalTime("2023-10-26 13:00").build());
-            itinerarys.add(
-                VisitResponseDTO.builder().itineraryId(3L).itineraryName("제주여정3").placeName("카멜리아힐")
-                    .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                    .arrivalTime("2023-10-26 16:00").build());
-            given(itineraryRepository.findAllByTripId(any(Long.TYPE))).willReturn(itineraryList);
+            Trip trip = Trip.builder().itineraries(itineraryList).build();
+            given(tripService.getTrip(any(Long.TYPE))).willReturn(trip);
 
             // when
             List<Object> itineraryResponseList = itineraryService.getItineraryByTripId(1L);
@@ -292,13 +278,13 @@ public class ItineraryServiceTest {
             // given
             VisitUpdateRequestDTO visitUpdateRequestDTO = VisitUpdateRequestDTO.builder()
                 .itineraryId(1L).itineraryName("즐거운 제주여정3").placeName("카멜리아힐")
-                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").departureTime("2023-10-26 14:00")
-                .arrivalTime("2023-10-26 16:00").build();
+                .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166").arrivalTime("2023-10-26 14:00")
+                .departureTime("2023-10-26 16:00").build();
             given(itineraryRepository.findById(any(Long.TYPE))).willReturn(Optional.of(
                 Itinerary.builder().id(3L).itineraryName("제주여정3").placeName("카멜리아힐")
                     .placeRoadAddressName("제주 서귀포시 안덕면 병악로 166")
-                    .departureTime(LocalDateTime.of(2023, 10, 26, 14, 0))
-                    .arrivalTime(LocalDateTime.of(2023, 10, 26, 16, 0)).trip(
+                    .arrivalTime(LocalDateTime.of(2023, 10, 26, 14, 0))
+                    .departureTime(LocalDateTime.of(2023, 10, 26, 16, 0)).trip(
                         Trip.builder().id(1L).startDate(LocalDate.of(2023, 10, 25))
                             .endDate(LocalDate.of(2023, 10, 26)).build()).build()));
 
@@ -307,7 +293,7 @@ public class ItineraryServiceTest {
 
             // then
             assertThat(result).extracting("itineraryName", "placeName", "placeRoadAddressName",
-                    "departureTime", "arrivalTime")
+                    "arrivalTime", "departureTime")
                 .containsExactly("즐거운 제주여정3", "카멜리아힐", "제주 서귀포시 안덕면 병악로 166", "2023-10-26 14:00",
                     "2023-10-26 16:00");
         }


### PR DESCRIPTION
### 문제 상황
- 여정 등록 시 여정 이름이 저장되지 않음
- 여행이 없어도 여정 조회가 가능함
- 여정 등록/수정 시 알맞지 않은 날짜를 입력해도 통과됨

### 해결 방안(개발 내용)
- 여정 등록 시 여정 이름도 저장하도록 수정
- 여정 조회 시 여행 조회를 우선적으로 하도록 수정
- 여정 등록/수정 시 날짜 검증을 추가로 하도록 수정